### PR TITLE
Fix(build): Correct production paths in component manifest

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -1,6 +1,6 @@
-// Auto-generated during build
+// Auto-generated file - DO NOT EDIT (production build)
 export const COMPONENT_PATHS = {
-  'about-page': () => import('./components/about-page/about-page.ts'),
-  'home-page': () => import('./components/home-page/home-page.ts'),
-  'nav-page': () => import('./components/nav-page/nav-page.ts'),
+  "about-page": () => import("/ts-wc-templater/assets/component_about-page.BGS0SxXE.js"),
+  "home-page": () => import("/ts-wc-templater/assets/component_home-page.CwM5gSyW.js"),
+  "nav-page": () => import("/ts-wc-templater/assets/component_nav-page.Cw80zz_3.js")
 };

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,6 +1,9 @@
 // Auto-generated file - DO NOT EDIT (production build)
 export const COMPONENT_PATHS = {
-  "about-page": () => import("/ts-wc-templater/assets/component_about-page.BGS0SxXE.js"),
-  "home-page": () => import("/ts-wc-templater/assets/component_home-page.CwM5gSyW.js"),
-  "nav-page": () => import("/ts-wc-templater/assets/component_nav-page.Cw80zz_3.js")
+  'about-page': () =>
+    import('/ts-wc-templater/assets/component_about-page.BGS0SxXE.js'),
+  'home-page': () =>
+    import('/ts-wc-templater/assets/component_home-page.CwM5gSyW.js'),
+  'nav-page': () =>
+    import('/ts-wc-templater/assets/component_nav-page.Cw80zz_3.js'),
 };

--- a/src/types/vite.env.d.ts
+++ b/src/types/vite.env.d.ts
@@ -14,19 +14,23 @@ declare module '*.html' {
 }
 
 declare module '../components' {
-  export const COMPONENT_PATHS: Record<string, () => Promise<any>>;
+  export const COMPONENT_PATHS: Record<
+    string,
+    () => Promise<{ default: typeof HTMLElement }>
+  >;
 }
 
 // For vite-plugin-component-manifest production paths
 declare module '/ts-wc-templater/assets/*.js' {
-  const component: () => Promise<{ default: CustomElementConstructor }>;
+  // Using typeof HTMLElement as a more robust type for custom element constructors
+  // in a .d.ts context, instead of CustomElementConstructor which might not always be resolved.
+  const component: () => Promise<{ default: typeof HTMLElement }>;
   export default component;
 }
 
-// Fallback for any other .js files that might be dynamically imported this way
-// if the above is too specific due to hashing or base path changes.
-// Consider if this is too broad or if the specific one is enough.
+// Fallback for any other .js files that might be dynamically imported this way.
+// Using 'any' here as the shape of miscellaneous JS files is unknown.
 declare module '*.js' {
-  const value: any;
+  const value: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   export default value;
 }

--- a/src/types/vite.env.d.ts
+++ b/src/types/vite.env.d.ts
@@ -16,3 +16,17 @@ declare module '*.html' {
 declare module '../components' {
   export const COMPONENT_PATHS: Record<string, () => Promise<any>>;
 }
+
+// For vite-plugin-component-manifest production paths
+declare module '/ts-wc-templater/assets/*.js' {
+  const component: () => Promise<{ default: CustomElementConstructor }>;
+  export default component;
+}
+
+// Fallback for any other .js files that might be dynamically imported this way
+// if the above is too specific due to hashing or base path changes.
+// Consider if this is too broad or if the specific one is enough.
+declare module '*.js' {
+  const value: any;
+  export default value;
+}

--- a/vite-plugin-component-manifest.ts
+++ b/vite-plugin-component-manifest.ts
@@ -4,80 +4,225 @@ import path from 'path';
 
 export default function componentManifest(): PluginOption {
   let componentsDir: string;
-  let isDev = false;
-  let config: ResolvedConfig; // Add this
+  let config: ResolvedConfig;
+  let isWatchMode = false;
 
-  const isProduction = process.env.NODE_ENV === 'production';
   return {
     name: 'vite-plugin-component-manifest',
+    config(userConfig, { command }) {
+      // Dynamically add components as Rollup inputs for build
+      if (command === 'build') {
+        const currentComponentsDir = normalizePath(path.resolve(userConfig.root || process.cwd(), 'src/components'));
+        const componentEntries: { [key: string]: string } = {};
+        try {
+          if (fs.existsSync(currentComponentsDir)) {
+            const componentNames = fs.readdirSync(currentComponentsDir).filter((name) => {
+              const componentPath = path.join(currentComponentsDir, name);
+              return fs.statSync(componentPath).isDirectory() &&
+                     fs.existsSync(path.join(componentPath, `${name}.ts`));
+            });
+            for (const name of componentNames) {
+              // Key for rollup input needs to be simple, value is the path
+              componentEntries[`component_${name}`] = normalizePath(path.resolve(currentComponentsDir, name, `${name}.ts`));
+            }
+          }
+        } catch (error) {
+          console.error("vite-plugin-component-manifest: Error scanning components for rollup input:", error);
+        }
+
+        if (Object.keys(componentEntries).length > 0) {
+          userConfig.build = userConfig.build || {};
+          userConfig.build.rollupOptions = userConfig.build.rollupOptions || {};
+          userConfig.build.rollupOptions.input = {
+            ...(userConfig.build.rollupOptions.input as object), // Keep existing inputs if any
+            ...componentEntries,
+            // Ensure main entry point is still present if not explicitly defined by user
+            main: normalizePath(path.resolve(userConfig.root || process.cwd(), 'index.html'))
+          };
+           console.log("vite-plugin-component-manifest: Added component entries to rollupOptions.input:", userConfig.build.rollupOptions.input);
+        }
+      }
+    },
     configResolved(resolvedConfig) {
-      config = resolvedConfig; // Store the config
+      config = resolvedConfig;
       componentsDir = normalizePath(
         path.resolve(config.root, 'src/components')
       );
-      isDev = config.command === 'serve';
-    },
-    configureServer() {
-      // Removed 'server' parameter
-      const generateManifest = () => {
-        const components = fs.readdirSync(componentsDir).filter((name) => {
-          const stats = fs.statSync(path.join(componentsDir, name));
-          return stats.isDirectory();
-        });
-
-        // Development: Use direct TS imports
-        const imports = components
-          .map((name) => {
-            const importPath = isProduction
-              ? `"/assets/${name}.js"` // Production path
-              : `"./components/${name}/${name}.ts"`; // Development path
-
-            return `"${name}": () => import(${importPath})`;
-          })
-          .join(',\n');
-
-        const content = `// Auto-generated file - DO NOT EDIT
-export const COMPONENT_PATHS = {
-  ${imports}
-};
-`;
-
-        fs.writeFileSync(
-          path.resolve(componentsDir, '../components.ts'),
-          content
-        );
-      };
-
-      generateManifest();
-      fs.watch(componentsDir, { recursive: true }, generateManifest);
+      if (config.command === 'serve' || (config.build.watch && config.command === 'build')) {
+        isWatchMode = true;
+      }
     },
     buildStart() {
-      if (!isDev) {
-        const generateManifest = () => {
+      // For production builds (not watch), ensure components.ts is clean initially
+      // This hook runs AFTER the config hook where inputs are set.
+      if (config.command === 'build' && !isWatchMode) { // isWatchMode check is more robust
+        const initialContent = `// Auto-generated file - DO NOT EDIT (build start)
+// This file is overwritten by generateBundle with actual production paths.
+export const COMPONENT_PATHS = {};
+`;
+        try {
+          // Ensure config object is available. It should be by buildStart.
+          if (!config || !config.root) {
+            console.error("vite-plugin-component-manifest: Config not available in buildStart. Skipping initialization of components.ts.");
+            return;
+          }
+          fs.writeFileSync(
+            path.resolve(config.root, 'src/components.ts'),
+            initialContent
+          );
+          // console.log("vite-plugin-component-manifest: Initialized src/components.ts for production build.");
+        } catch (error) {
+          console.error("vite-plugin-component-manifest: Error initializing src/components.ts:", error);
+        }
+      }
+    },
+    configureServer() {
+      // This hook is only for the dev server and build --watch
+      const generateManifestForDev = () => {
+        try {
           const components = fs.readdirSync(componentsDir).filter((name) => {
-            const stats = fs.statSync(path.join(componentsDir, name));
-            return stats.isDirectory();
+            const componentPath = path.join(componentsDir, name);
+            // Check if it's a directory and contains a .ts file with the same name
+            return fs.statSync(componentPath).isDirectory() &&
+                   fs.existsSync(path.join(componentPath, `${name}.ts`));
           });
 
-          // Production: Use plain asset paths (no base prefix)
           const imports = components
-            .map(
-              (name) =>
-                `'${name}': () => import('./components/${name}/${name}.ts')`
-            )
+            .map((name) => {
+              // For dev, paths are relative from src/ to src/components/name/name.ts
+              const importPath = `./components/${name}/${name}.ts`;
+              return `  "${name}": () => import("${importPath}")`;
+            })
             .join(',\n');
 
-          const content = `// Auto-generated during build
-                export const COMPONENT_PATHS = {
-                    ${imports}
-            }; \n`;
-
+          const content = `// Auto-generated file - DO NOT EDIT (dev mode)
+export const COMPONENT_PATHS = {
+${imports}
+};
+`;
           fs.writeFileSync(
-            path.resolve(componentsDir, '../components.ts'),
+            path.resolve(config.root, 'src/components.ts'),
             content
           );
-        };
-        generateManifest();
+        } catch (error) {
+          console.error('Error generating component manifest for dev:', error);
+        }
+      };
+
+      generateManifestForDev();
+      fs.watch(componentsDir, { recursive: true }, (eventType, filename) => {
+        if (filename) {
+          console.log(`Detected change in ${filename}, regenerating component manifest...`);
+          generateManifestForDev();
+        }
+      });
+    },
+    generateBundle(options, bundle) {
+      // This hook is for production builds
+      if (isWatchMode && config.command === 'build') {
+        // If it's `vite build --watch`, we still want dev-like paths for HMR
+        // The configureServer logic should handle this by continuously writing dev paths.
+        // However, to be safe, if generateBundle is called in watch mode,
+        // we ensure dev paths are written, as final asset paths might not be stable.
+        try {
+            const components = fs.readdirSync(componentsDir).filter((name) => {
+                const componentPath = path.join(componentsDir, name);
+                return fs.statSync(componentPath).isDirectory() &&
+                       fs.existsSync(path.join(componentPath, `${name}.ts`));
+            });
+
+            const imports = components
+                .map((name) => `  "${name}": () => import("./components/${name}/${name}.ts")`)
+                .join(',\n');
+
+            const content = `// Auto-generated file - DO NOT EDIT (build --watch)
+export const COMPONENT_PATHS = {
+${imports}
+};
+`;
+            fs.writeFileSync(
+                path.resolve(config.root, 'src/components.ts'),
+                content
+            );
+        } catch (error) {
+            console.error('Error generating component manifest for build --watch:', error);
+        }
+        return;
+      }
+
+
+      // Proceed with production path generation only if not in watch mode build
+      if (config.command === 'build' && !config.build.watch) {
+        const imports: string[] = [];
+        const componentInputMatcher = /src\/components\/([^\/]+)\/\1\.ts$/;
+
+        console.log("--- Component Manifest Plugin: generateBundle ---");
+        console.log("Bundle object:", JSON.stringify(Object.keys(bundle), null, 2));
+
+        for (const [fileName, chunkInfo] of Object.entries(bundle)) {
+          if (chunkInfo.type === 'chunk') {
+            console.log(`\nProcessing chunk: ${fileName}`);
+            console.log(`  Is Entry: ${chunkInfo.isEntry}`);
+            console.log(`  Facade Module ID: ${chunkInfo.facadeModuleId ? normalizePath(chunkInfo.facadeModuleId) : 'N/A'}`);
+            console.log(`  Chunk Name: ${chunkInfo.name}`);
+            console.log(`  Chunk File Name: ${chunkInfo.fileName}`);
+            console.log(`  Chunk Imports: ${JSON.stringify(chunkInfo.imports)}`);
+            console.log(`  Chunk Dynamic Imports: ${JSON.stringify(chunkInfo.dynamicImports)}`);
+            console.log(`  Modules in chunk: ${Object.keys(chunkInfo.modules).map(m => normalizePath(m)).join(', ')}`)
+
+
+            // facadeModuleId is the original entry point for this chunk
+            const facadeId = chunkInfo.facadeModuleId;
+            if (facadeId && componentInputMatcher.test(normalizePath(facadeId))) {
+              const match = normalizePath(facadeId).match(componentInputMatcher);
+              if (match && match[1]) {
+                const componentName = match[1];
+                const importPath = path.posix.join(config.base, chunkInfo.fileName);
+                imports.push(`  "${componentName}": () => import("${importPath}")`);
+                console.log(`    -> Found component: ${componentName}, Path: ${importPath}`);
+              }
+            } else if (chunkInfo.isEntry) {
+                // If it's an entry chunk but didn't match the facadeId pattern,
+                // let's try to find if any of its modules match our component structure.
+                // This is a fallback, as ideally facadeModuleId should work for entries.
+                for (const moduleId of Object.keys(chunkInfo.modules)) {
+                    const normalizedModuleId = normalizePath(moduleId);
+                    if(componentInputMatcher.test(normalizedModuleId)) {
+                        const match = normalizedModuleId.match(componentInputMatcher);
+                        if (match && match[1]) {
+                            const componentName = match[1];
+                            // Check if this component name was already added via facadeModuleId
+                            if (!imports.some(imp => imp.includes(`"${componentName}"`))) {
+                                const importPath = path.posix.join(config.base, chunkInfo.fileName);
+                                imports.push(`  "${componentName}": () => import("${importPath}")`);
+                                console.log(`    -> Found component (via modules scan): ${componentName}, Path: ${importPath}`);
+                            }
+                            break; // Found component for this chunk
+                        }
+                    }
+                }
+            }
+          }
+        }
+        console.log("--- End Component Manifest Plugin ---");
+
+        if (imports.length === 0) {
+            console.warn("vite-plugin-component-manifest: No component entry points found in the bundle. components.ts will be empty.");
+        }
+
+        const content = `// Auto-generated file - DO NOT EDIT (production build)
+export const COMPONENT_PATHS = {
+${imports.join(',\n')}
+};
+`;
+        // Output to src/components.ts, which is then processed by the build
+        // This ensures it's part of the final application bundle correctly.
+        // It might be better to emit this as a virtual module or directly into dist,
+        // but for now, this matches the existing behavior of writing to src/.
+        fs.writeFileSync(
+          path.resolve(config.root, 'src/components.ts'),
+          content
+        );
       }
     },
   };

--- a/vite-plugin-component-manifest.ts
+++ b/vite-plugin-component-manifest.ts
@@ -12,22 +12,33 @@ export default function componentManifest(): PluginOption {
     config(userConfig, { command }) {
       // Dynamically add components as Rollup inputs for build
       if (command === 'build') {
-        const currentComponentsDir = normalizePath(path.resolve(userConfig.root || process.cwd(), 'src/components'));
+        const currentComponentsDir = normalizePath(
+          path.resolve(userConfig.root || process.cwd(), 'src/components')
+        );
         const componentEntries: { [key: string]: string } = {};
         try {
           if (fs.existsSync(currentComponentsDir)) {
-            const componentNames = fs.readdirSync(currentComponentsDir).filter((name) => {
-              const componentPath = path.join(currentComponentsDir, name);
-              return fs.statSync(componentPath).isDirectory() &&
-                     fs.existsSync(path.join(componentPath, `${name}.ts`));
-            });
+            const componentNames = fs
+              .readdirSync(currentComponentsDir)
+              .filter((name) => {
+                const componentPath = path.join(currentComponentsDir, name);
+                return (
+                  fs.statSync(componentPath).isDirectory() &&
+                  fs.existsSync(path.join(componentPath, `${name}.ts`))
+                );
+              });
             for (const name of componentNames) {
               // Key for rollup input needs to be simple, value is the path
-              componentEntries[`component_${name}`] = normalizePath(path.resolve(currentComponentsDir, name, `${name}.ts`));
+              componentEntries[`component_${name}`] = normalizePath(
+                path.resolve(currentComponentsDir, name, `${name}.ts`)
+              );
             }
           }
         } catch (error) {
-          console.error("vite-plugin-component-manifest: Error scanning components for rollup input:", error);
+          console.error(
+            'vite-plugin-component-manifest: Error scanning components for rollup input:',
+            error
+          );
         }
 
         if (Object.keys(componentEntries).length > 0) {
@@ -37,9 +48,14 @@ export default function componentManifest(): PluginOption {
             ...(userConfig.build.rollupOptions.input as object), // Keep existing inputs if any
             ...componentEntries,
             // Ensure main entry point is still present if not explicitly defined by user
-            main: normalizePath(path.resolve(userConfig.root || process.cwd(), 'index.html'))
+            main: normalizePath(
+              path.resolve(userConfig.root || process.cwd(), 'index.html')
+            ),
           };
-           console.log("vite-plugin-component-manifest: Added component entries to rollupOptions.input:", userConfig.build.rollupOptions.input);
+          console.log(
+            'vite-plugin-component-manifest: Added component entries to rollupOptions.input:',
+            userConfig.build.rollupOptions.input
+          );
         }
       }
     },
@@ -48,14 +64,18 @@ export default function componentManifest(): PluginOption {
       componentsDir = normalizePath(
         path.resolve(config.root, 'src/components')
       );
-      if (config.command === 'serve' || (config.build.watch && config.command === 'build')) {
+      if (
+        config.command === 'serve' ||
+        (config.build.watch && config.command === 'build')
+      ) {
         isWatchMode = true;
       }
     },
     buildStart() {
       // For production builds (not watch), ensure components.ts is clean initially
       // This hook runs AFTER the config hook where inputs are set.
-      if (config.command === 'build' && !isWatchMode) { // isWatchMode check is more robust
+      if (config.command === 'build' && !isWatchMode) {
+        // isWatchMode check is more robust
         const initialContent = `// Auto-generated file - DO NOT EDIT (build start)
 // This file is overwritten by generateBundle with actual production paths.
 export const COMPONENT_PATHS = {};
@@ -63,7 +83,9 @@ export const COMPONENT_PATHS = {};
         try {
           // Ensure config object is available. It should be by buildStart.
           if (!config || !config.root) {
-            console.error("vite-plugin-component-manifest: Config not available in buildStart. Skipping initialization of components.ts.");
+            console.error(
+              'vite-plugin-component-manifest: Config not available in buildStart. Skipping initialization of components.ts.'
+            );
             return;
           }
           fs.writeFileSync(
@@ -72,7 +94,10 @@ export const COMPONENT_PATHS = {};
           );
           // console.log("vite-plugin-component-manifest: Initialized src/components.ts for production build.");
         } catch (error) {
-          console.error("vite-plugin-component-manifest: Error initializing src/components.ts:", error);
+          console.error(
+            'vite-plugin-component-manifest: Error initializing src/components.ts:',
+            error
+          );
         }
       }
     },
@@ -83,21 +108,22 @@ export const COMPONENT_PATHS = {};
           const components = fs.readdirSync(componentsDir).filter((name) => {
             const componentPath = path.join(componentsDir, name);
             // Check if it's a directory and contains a .ts file with the same name
-            return fs.statSync(componentPath).isDirectory() &&
-                   fs.existsSync(path.join(componentPath, `${name}.ts`));
+            return (
+              fs.statSync(componentPath).isDirectory() &&
+              fs.existsSync(path.join(componentPath, `${name}.ts`))
+            );
           });
 
-          const imports = components
-            .map((name) => {
-              // For dev, paths are relative from src/ to src/components/name/name.ts
-              const importPath = `./components/${name}/${name}.ts`;
-              return `  "${name}": () => import("${importPath}")`;
-            })
-            .join(',\n');
+          const importEntries = components.map(
+            (name) =>
+              // Formatting to generally match Prettier's defaults
+              `  '${name}': () =>
+    import('./components/${name}/${name}.ts')`
+          );
 
           const content = `// Auto-generated file - DO NOT EDIT (dev mode)
 export const COMPONENT_PATHS = {
-${imports}
+${importEntries.join(',\n')}
 };
 `;
           fs.writeFileSync(
@@ -112,7 +138,9 @@ ${imports}
       generateManifestForDev();
       fs.watch(componentsDir, { recursive: true }, (eventType, filename) => {
         if (filename) {
-          console.log(`Detected change in ${filename}, regenerating component manifest...`);
+          console.log(
+            `Detected change in ${filename}, regenerating component manifest...`
+          );
           generateManifestForDev();
         }
       });
@@ -125,94 +153,144 @@ ${imports}
         // However, to be safe, if generateBundle is called in watch mode,
         // we ensure dev paths are written, as final asset paths might not be stable.
         try {
-            const components = fs.readdirSync(componentsDir).filter((name) => {
-                const componentPath = path.join(componentsDir, name);
-                return fs.statSync(componentPath).isDirectory() &&
-                       fs.existsSync(path.join(componentPath, `${name}.ts`));
-            });
+          const components = fs.readdirSync(componentsDir).filter((name) => {
+            const componentPath = path.join(componentsDir, name);
+            return (
+              fs.statSync(componentPath).isDirectory() &&
+              fs.existsSync(path.join(componentPath, `${name}.ts`))
+            );
+          });
 
-            const imports = components
-                .map((name) => `  "${name}": () => import("./components/${name}/${name}.ts")`)
-                .join(',\n');
+          const componentNames = components; // Assuming 'components' is the list of names
+          const importEntries = componentNames.map(
+            (name) =>
+              `  '${name}': () =>
+    import('./components/${name}/${name}.ts')`
+          );
 
-            const content = `// Auto-generated file - DO NOT EDIT (build --watch)
+          const content = `// Auto-generated file - DO NOT EDIT (build --watch)
 export const COMPONENT_PATHS = {
-${imports}
+${importEntries.join(',\n')}${importEntries.length > 0 ? ',' : ''}
 };
 `;
-            fs.writeFileSync(
-                path.resolve(config.root, 'src/components.ts'),
-                content
-            );
+          fs.writeFileSync(
+            path.resolve(config.root, 'src/components.ts'),
+            content
+          );
         } catch (error) {
-            console.error('Error generating component manifest for build --watch:', error);
+          console.error(
+            'Error generating component manifest for build --watch:',
+            error
+          );
         }
         return;
       }
 
-
       // Proceed with production path generation only if not in watch mode build
       if (config.command === 'build' && !config.build.watch) {
         const imports: string[] = [];
-        const componentInputMatcher = /src\/components\/([^\/]+)\/\1\.ts$/;
+        // Corrected regex: removed unnecessary escape for / within [^...]
+        const componentInputMatcher = /src\/components\/([^/]+)\/\1\.ts$/;
 
-        console.log("--- Component Manifest Plugin: generateBundle ---");
-        console.log("Bundle object:", JSON.stringify(Object.keys(bundle), null, 2));
+        console.log('--- Component Manifest Plugin: generateBundle ---');
+        console.log(
+          'Bundle object:',
+          JSON.stringify(Object.keys(bundle), null, 2)
+        );
 
         for (const [fileName, chunkInfo] of Object.entries(bundle)) {
           if (chunkInfo.type === 'chunk') {
             console.log(`\nProcessing chunk: ${fileName}`);
             console.log(`  Is Entry: ${chunkInfo.isEntry}`);
-            console.log(`  Facade Module ID: ${chunkInfo.facadeModuleId ? normalizePath(chunkInfo.facadeModuleId) : 'N/A'}`);
+            console.log(
+              `  Facade Module ID: ${chunkInfo.facadeModuleId ? normalizePath(chunkInfo.facadeModuleId) : 'N/A'}`
+            );
             console.log(`  Chunk Name: ${chunkInfo.name}`);
             console.log(`  Chunk File Name: ${chunkInfo.fileName}`);
-            console.log(`  Chunk Imports: ${JSON.stringify(chunkInfo.imports)}`);
-            console.log(`  Chunk Dynamic Imports: ${JSON.stringify(chunkInfo.dynamicImports)}`);
-            console.log(`  Modules in chunk: ${Object.keys(chunkInfo.modules).map(m => normalizePath(m)).join(', ')}`)
-
+            console.log(
+              `  Chunk Imports: ${JSON.stringify(chunkInfo.imports)}`
+            );
+            console.log(
+              `  Chunk Dynamic Imports: ${JSON.stringify(chunkInfo.dynamicImports)}`
+            );
+            console.log(
+              `  Modules in chunk: ${Object.keys(chunkInfo.modules)
+                .map((m) => normalizePath(m))
+                .join(', ')}`
+            );
 
             // facadeModuleId is the original entry point for this chunk
             const facadeId = chunkInfo.facadeModuleId;
-            if (facadeId && componentInputMatcher.test(normalizePath(facadeId))) {
-              const match = normalizePath(facadeId).match(componentInputMatcher);
+            if (
+              facadeId &&
+              componentInputMatcher.test(normalizePath(facadeId))
+            ) {
+              const match = normalizePath(facadeId).match(
+                componentInputMatcher
+              );
               if (match && match[1]) {
                 const componentName = match[1];
-                const importPath = path.posix.join(config.base, chunkInfo.fileName);
-                imports.push(`  "${componentName}": () => import("${importPath}")`);
-                console.log(`    -> Found component: ${componentName}, Path: ${importPath}`);
+                const importPath = path.posix.join(
+                  config.base,
+                  chunkInfo.fileName
+                );
+                // Formatting to generally match Prettier's defaults
+                imports.push(
+                  `  '${componentName}': () =>
+    import('${importPath}')`
+                );
+                console.log(
+                  `    -> Found component: ${componentName}, Path: ${importPath}`
+                );
               }
             } else if (chunkInfo.isEntry) {
-                // If it's an entry chunk but didn't match the facadeId pattern,
-                // let's try to find if any of its modules match our component structure.
-                // This is a fallback, as ideally facadeModuleId should work for entries.
-                for (const moduleId of Object.keys(chunkInfo.modules)) {
-                    const normalizedModuleId = normalizePath(moduleId);
-                    if(componentInputMatcher.test(normalizedModuleId)) {
-                        const match = normalizedModuleId.match(componentInputMatcher);
-                        if (match && match[1]) {
-                            const componentName = match[1];
-                            // Check if this component name was already added via facadeModuleId
-                            if (!imports.some(imp => imp.includes(`"${componentName}"`))) {
-                                const importPath = path.posix.join(config.base, chunkInfo.fileName);
-                                imports.push(`  "${componentName}": () => import("${importPath}")`);
-                                console.log(`    -> Found component (via modules scan): ${componentName}, Path: ${importPath}`);
-                            }
-                            break; // Found component for this chunk
-                        }
+              // If it's an entry chunk but didn't match the facadeId pattern,
+              // let's try to find if any of its modules match our component structure.
+              // This is a fallback, as ideally facadeModuleId should work for entries.
+              for (const moduleId of Object.keys(chunkInfo.modules)) {
+                const normalizedModuleId = normalizePath(moduleId);
+                if (componentInputMatcher.test(normalizedModuleId)) {
+                  const match = normalizedModuleId.match(componentInputMatcher);
+                  if (match && match[1]) {
+                    const componentName = match[1];
+                    // Check if this component name was already added via facadeModuleId
+                    if (
+                      !imports.some(
+                        (imp) => imp.includes(`'${componentName}'`) // Check with single quotes
+                      )
+                    ) {
+                      const importPath = path.posix.join(
+                        config.base,
+                        chunkInfo.fileName
+                      );
+                      // Formatting to generally match Prettier's defaults
+                      imports.push(
+                        `  '${componentName}': () =>
+    import('${importPath}')`
+                      );
+                      console.log(
+                        `    -> Found component (via modules scan): ${componentName}, Path: ${importPath}`
+                      );
                     }
+                    break; // Found component for this chunk
+                  }
                 }
+              }
             }
           }
         }
-        console.log("--- End Component Manifest Plugin ---");
+        console.log('--- End Component Manifest Plugin ---');
 
         if (imports.length === 0) {
-            console.warn("vite-plugin-component-manifest: No component entry points found in the bundle. components.ts will be empty.");
+          console.warn(
+            'vite-plugin-component-manifest: No component entry points found in the bundle. components.ts will be empty.'
+          );
         }
 
+        const formattedImports = imports.join(',\n');
         const content = `// Auto-generated file - DO NOT EDIT (production build)
 export const COMPONENT_PATHS = {
-${imports.join(',\n')}
+${formattedImports}${imports.length > 0 ? ',' : ''}
 };
 `;
         // Output to src/components.ts, which is then processed by the build


### PR DESCRIPTION
The vite-plugin-component-manifest was generating incorrect paths to component .ts files in production builds. This commit updates the plugin to:

1. Dynamically add components from `src/components/*/*.ts` as explicit Rollup inputs during the `config` hook. This ensures Vite creates separate, hashable chunks for each component.
2. Initialize `src/components.ts` with empty paths during the `buildStart` hook for production builds. This prevents stale paths from previous builds from causing resolution errors early in the Vite/Rollup build process.
3. Utilize the `generateBundle` hook to iterate over the final output bundle. It identifies the component chunks (now easily identifiable due to being explicit inputs) and generates the `src/components.ts` manifest file with correct, hashed asset paths suitable for production dynamic imports.
4. Ensure that development mode (`vite` or `vite build --watch`) continues to generate direct paths to `.ts` files in the manifest for optimal HMR and debugging, handled by the `configureServer` hook.