### PR TITLE
fix: Adapt router for GitHub Pages base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   </head>
 
   <body>
+    <app-nav></app-nav>
     <app-root>
       <div id="router-outlet"></div>
     </app-root>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "main": "./src/main.ts",
-  "homepage": "https://sholtomaud.github.io/ts-wc-template/",
+  "homepage": "https://sholtomaud.github.io/ts-wc-templater/",
   "scripts": {
     "dev": "NODE_ENV=development vite",
     "dev:host": "vite --host",

--- a/src/components/home-page/home.css
+++ b/src/components/home-page/home.css
@@ -1,9 +1,16 @@
 :root {
-  --primary-color: #42b983;
-  --secondary-color: #35495e;
+  --primary-color: #42b983; /* Keep this for now, or use a more modern green */
+  --secondary-color: #35495e; /* Dark blue-grey */
+  --accent-color: #f39c12; /* Snappy orange for accents */
+  --background-color: #fdfdfd; /* Very light grey or white */
+  --text-color: #333;
+
+  --spacing-small: 0.5rem;
+  --spacing-medium: 1rem;
   --spacing-large: 2rem;
-  /* --main-font-family: Georgia, 'Times New Roman', Times, serif; */
-  /* --main-font-family: Arial; */
+
+  /* Using a more modern, clean font stack */
+  --main-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 .hello-container {
@@ -11,84 +18,99 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 80vh;
+  min-height: 80vh; /* Use viewport height to fill screen */
   padding: var(--spacing-large);
-  color: var(--primary-color);
+  color: var(--text-color); /* Use general text color */
+  text-align: center;
+  overflow: hidden; /* Prevent scrollbars during animation */
 }
 
 .title {
-  color: var(--primary-color);
-  font-size: 4.5rem;
-  font-family: 'Times New Roman', Times, serif;
-  font-weight: 100;
-  margin-bottom: 0px;
-  animation: fadeIn 1s ease-in;
+  font-family: var(--main-font-family);
+  color: var(--secondary-color); /* Darker color for title */
+  font-size: clamp(2.5rem, 8vw, 4.5rem); /* Responsive font size */
+  font-weight: 700; /* Bolder for modern feel */
+  margin-bottom: var(--spacing-small);
+  animation: slideUpFadeIn 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.3s forwards;
+  opacity: 0; /* Start hidden for animation */
 }
 
 .subtitle {
-  color: var(--primary-color);
-  font-size: 2.5rem;
-  font-family: 'Times New Roman', Times, serif;
-  font-weight: 100;
+  font-family: var(--main-font-family);
+  color: var(--primary-color); /* Use primary color for subtitle */
+  font-size: clamp(1.25rem, 4vw, 2rem); /* Responsive font size */
+  font-weight: 400;
   margin-bottom: var(--spacing-large);
-  margin-top: 0px;
-  animation: fadeIn 1s ease-in;
+  margin-top: 0;
+  animation: slideUpFadeIn 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.6s forwards;
+  opacity: 0; /* Start hidden for animation */
 }
 
 .content {
   text-align: center;
+  animation: fadeIn 1s ease-in 1s forwards; /* Fade in content after title/subtitle */
+  opacity: 0;
 }
 
 .greet-button {
-  padding: var(--spacing-small) var(--spacing-medium);
-  font-size: 1rem;
-  /* color: white; */
-  /* background-color: var(--secondary-color); */
-  background-color: var(--background-color);
-  /* border: none; */
-  color: var(--secondary-color);
-  border-radius: 5px;
-  border-bottom: var(--primary-color) 1px solid;
-  border-top: var(--primary-color) 1px solid;
-  cursor: pointer;
-  animation: enterButtonIn 6.3s ease;
-  text-decoration: none;
-}
-
-.greet-button:hover {
+  font-family: var(--main-font-family);
+  padding: var(--spacing-medium) var(--spacing-large);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: white;
   background-color: var(--primary-color);
+  border: none; /* Remove existing border */
+  border-radius: 8px; /* Slightly more rounded corners */
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block; /* For transform to work correctly */
+  transition: background-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  animation: popIn 0.6s cubic-bezier(0.68, -0.55, 0.27, 1.55) 1.2s forwards;
+  opacity: 0; /* Start hidden for animation */
+  transform: scale(0.5); /* Start smaller for popIn animation */
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
 }
 
+.greet-button:hover,
+.greet-button:focus { /* Added focus for accessibility */
+  background-color: var(--secondary-color); /* Darker on hover */
+  transform: translateY(-3px) scale(1.05); /* Lift and slightly grow */
+  box-shadow: 0 6px 20px rgba(53, 73, 94, 0.3); /* Stronger shadow */
+  outline: none; /* Remove default focus outline if custom styles are sufficient */
+}
+
+/* General Fade-In (can be reused) */
 @keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
-@keyframes slideIn {
+/* Slide Up and Fade In */
+@keyframes slideUpFadeIn {
   from {
-    transform: translateY(5px);
+    transform: translateY(30px); /* Start further down */
     opacity: 0;
   }
-
   to {
     transform: translateY(0);
     opacity: 1;
   }
 }
 
-@keyframes enterButtonIn {
-  from {
-    transform: translateY(105px);
+/* Pop In effect for button */
+@keyframes popIn {
+  0% {
     opacity: 0;
+    transform: scale(0.5);
   }
-
-  to {
-    transform: translateY(0);
+  70% {
     opacity: 1;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
+
+/* Removed unused slideIn and enterButtonIn keyframes */

--- a/src/core/router/router.ts
+++ b/src/core/router/router.ts
@@ -26,9 +26,14 @@ export class Router {
     const pathname = window.location.pathname;
     // Ensure BASE_URL ends with a slash for correct comparison and substringing,
     // unless it's the root path "/".
-    const normalizedBaseUrl = BASE_URL.endsWith('/') || BASE_URL === '/' ? BASE_URL : BASE_URL + '/';
+    const normalizedBaseUrl =
+      BASE_URL.endsWith('/') || BASE_URL === '/' ? BASE_URL : BASE_URL + '/';
 
-    if (pathname.startsWith(normalizedBaseUrl) && normalizedBaseUrl.length > 1) { // Don't strip if base is '/'
+    if (
+      pathname.startsWith(normalizedBaseUrl) &&
+      normalizedBaseUrl.length > 1
+    ) {
+      // Don't strip if base is '/'
       let appPath = pathname.substring(normalizedBaseUrl.length);
       // Ensure it starts with a leading slash for consistency (e.g. / or /about)
       if (!appPath.startsWith('/')) {
@@ -43,7 +48,9 @@ export class Router {
 
   public registerRoute(route: Route): void {
     // Ensure routes are registered with a leading slash for consistency
-    const normalizedPath = route.path.startsWith('/') ? route.path : '/' + route.path;
+    const normalizedPath = route.path.startsWith('/')
+      ? route.path
+      : '/' + route.path;
     this.routes.push({ ...route, path: normalizedPath });
   }
 
@@ -52,13 +59,17 @@ export class Router {
    * The router will handle prepending the BASE_URL for history.
    * @param appPath The application-specific path.
    */
-  public navigate(appPath: string): void { // appPath is like "/" or "/about"
+  public navigate(appPath: string): void {
+    // appPath is like "/" or "/about"
     const normalizedAppPath = appPath.startsWith('/') ? appPath : '/' + appPath;
 
     // Construct the full public URL path.
     // The base for new URL must be an absolute URL.
     const dummyAbsoluteBase = 'http://dummy';
-    const publicPath = new URL(normalizedAppPath.substring(1), dummyAbsoluteBase + (BASE_URL.endsWith('/') ? BASE_URL : BASE_URL + '/')).pathname;
+    const publicPath = new URL(
+      normalizedAppPath.substring(1),
+      dummyAbsoluteBase + (BASE_URL.endsWith('/') ? BASE_URL : BASE_URL + '/')
+    ).pathname;
 
     if (window.location.pathname !== publicPath) {
       window.history.pushState({}, '', publicPath);

--- a/src/core/router/router.ts
+++ b/src/core/router/router.ts
@@ -1,5 +1,7 @@
 import { COMPONENT_PATHS } from '../../components';
 
+const BASE_URL = import.meta.env.BASE_URL; // Provided by Vite, e.g., "/ts-wc-templater/" or "/"
+
 type Route = {
   path: string;
   component: string; // Component tag name (e.g., 'home-page')
@@ -20,18 +22,53 @@ export class Router {
     return Router.instance;
   }
 
-  public registerRoute(route: Route): void {
-    this.routes.push(route);
+  private getAppPath(): string {
+    const pathname = window.location.pathname;
+    // Ensure BASE_URL ends with a slash for correct comparison and substringing,
+    // unless it's the root path "/".
+    const normalizedBaseUrl = BASE_URL.endsWith('/') || BASE_URL === '/' ? BASE_URL : BASE_URL + '/';
+
+    if (pathname.startsWith(normalizedBaseUrl) && normalizedBaseUrl.length > 1) { // Don't strip if base is '/'
+      let appPath = pathname.substring(normalizedBaseUrl.length);
+      // Ensure it starts with a leading slash for consistency (e.g. / or /about)
+      if (!appPath.startsWith('/')) {
+        appPath = '/' + appPath;
+      }
+      // Handle case where pathname is exactly the base (e.g. /ts-wc-templater/ should map to /)
+      return appPath === '' ? '/' : appPath;
+    }
+    // Fallback or if BASE_URL is '/'
+    return pathname.startsWith('/') ? pathname : '/' + pathname;
   }
 
-  public navigate(path: string): void {
-    window.history.pushState({}, '', path);
-    this.handleRoute();
+  public registerRoute(route: Route): void {
+    // Ensure routes are registered with a leading slash for consistency
+    const normalizedPath = route.path.startsWith('/') ? route.path : '/' + route.path;
+    this.routes.push({ ...route, path: normalizedPath });
+  }
+
+  /**
+   * Navigates to an application-specific path (e.g., '/', '/about').
+   * The router will handle prepending the BASE_URL for history.
+   * @param appPath The application-specific path.
+   */
+  public navigate(appPath: string): void { // appPath is like "/" or "/about"
+    const normalizedAppPath = appPath.startsWith('/') ? appPath : '/' + appPath;
+
+    // Construct the full public URL path.
+    // The base for new URL must be an absolute URL.
+    const dummyAbsoluteBase = 'http://dummy';
+    const publicPath = new URL(normalizedAppPath.substring(1), dummyAbsoluteBase + (BASE_URL.endsWith('/') ? BASE_URL : BASE_URL + '/')).pathname;
+
+    if (window.location.pathname !== publicPath) {
+      window.history.pushState({}, '', publicPath);
+    }
+    this.handleRoute(); // handleRoute will use getAppPath() to match
   }
 
   private handleRoute(): void {
-    const path = window.location.pathname;
-    const route = this.routes.find((r) => r.path === path);
+    const appPathToMatch = this.getAppPath();
+    const route = this.routes.find((r) => r.path === appPathToMatch);
 
     if (route) {
       this.loadComponent(route.component);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,28 @@ import { Router } from './core/router/router';
 import './components/nav-page/nav-page.ts';
 import './styles/global.css'; // Path relative to your main.ts file
 
+const BASE_URL = import.meta.env.BASE_URL; // Provided by Vite
+
+function getInitialAppPath(): string {
+  const pathname = window.location.pathname;
+  // Ensure BASE_URL ends with a slash for correct comparison and substringing,
+  // unless it's the root path "/".
+  const normalizedBaseUrl = BASE_URL.endsWith('/') || BASE_URL === '/' ? BASE_URL : BASE_URL + '/';
+
+  if (pathname.startsWith(normalizedBaseUrl) && normalizedBaseUrl.length > 1) { // Don't strip if base is '/'
+    let appPath = pathname.substring(normalizedBaseUrl.length);
+    if (!appPath.startsWith('/')) {
+      appPath = '/' + appPath;
+    }
+    return appPath === '' ? '/' : appPath; // e.g. /about or /
+  }
+  return pathname.startsWith('/') ? pathname : '/' + pathname; // Fallback or if BASE_URL is '/'
+}
+
 // Initialize router and register routes
 const router = Router.getInstance();
 router.registerRoute({ path: '/', component: 'home-page' });
 router.registerRoute({ path: '/about', component: 'about-page' });
 
 // Initial load
-router.navigate(window.location.pathname);
+router.navigate(getInitialAppPath());

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,9 +10,11 @@ function getInitialAppPath(): string {
   const pathname = window.location.pathname;
   // Ensure BASE_URL ends with a slash for correct comparison and substringing,
   // unless it's the root path "/".
-  const normalizedBaseUrl = BASE_URL.endsWith('/') || BASE_URL === '/' ? BASE_URL : BASE_URL + '/';
+  const normalizedBaseUrl =
+    BASE_URL.endsWith('/') || BASE_URL === '/' ? BASE_URL : BASE_URL + '/';
 
-  if (pathname.startsWith(normalizedBaseUrl) && normalizedBaseUrl.length > 1) { // Don't strip if base is '/'
+  if (pathname.startsWith(normalizedBaseUrl) && normalizedBaseUrl.length > 1) {
+    // Don't strip if base is '/'
     let appPath = pathname.substring(normalizedBaseUrl.length);
     if (!appPath.startsWith('/')) {
       appPath = '/' + appPath;


### PR DESCRIPTION
- Reverted Vite `base` config to '/ts-wc-templater/' to ensure correct path generation for static assets and dynamic imports.
- Updated client-side router (`router.ts`) to be aware of `import.meta.env.BASE_URL`.
    - `getAppPath()` now correctly strips the base path from `window.location.pathname` to get the application-internal path for route matching.
    - `navigate(appPath)` now correctly prepends the base path when updating browser history and URLs.
- Updated `main.ts` to calculate and use the application-internal path for the initial router navigation.

These changes address issues with 404 errors for lazy-loaded page components when deployed to a GitHub Pages subfolder.