### PR TITLE
Fix: Configure Vite base path and GitHub Pages for SPA routing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Prepare 404 page for SPA
+        run: cp dist/index.html dist/404.html
+
       - name: Add .nojekyll
         run: touch dist/.nojekyll
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import componentManifest from './vite-plugin-component-manifest';
 
 export default defineConfig(({ command }) => ({
-  base: command === 'build' ? './' : '/',
+  base: command === 'build' ? '/ts-wc-templates/' : '/',
   plugins: [componentManifest()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
- Updated `vite.config.ts` to set `base: '/ts-wc-templates/'` for production builds. This ensures that `import.meta.env.BASE_URL` is correctly set and asset paths are properly prefixed for deployment to GitHub Pages under a subdirectory.
- Modified `.github/workflows/deploy.yml` to copy `dist/index.html` to `dist/404.html` after the build process. This allows GitHub Pages to serve the main application file for any unmatched paths, enabling the client-side router to handle deep links correctly.

These changes address the issue where the application would show a 404 page because the client-side router was not correctly interpreting paths relative to the GitHub Pages deployment structure.