### PR TITLE
Fix: Correct import for COMPONENT_PATHS in router

### DIFF
--- a/src/core/router/router.ts
+++ b/src/core/router/router.ts
@@ -1,4 +1,4 @@
-import { COMPONENT_PATHS } from '../../components';
+import { COMPONENT_PATHS } from 'virtual:component-manifest';
 
 const BASE_URL = import.meta.env.BASE_URL; // Provided by Vite, e.g., "/ts-wc-templater/" or "/"
 


### PR DESCRIPTION
- Changed the import for `COMPONENT_PATHS` in `src/core/router/router.ts` from `../../components` to the virtual module `virtual:component-manifest`.
- Verified that the `vite-plugin-component-manifest` correctly generates paths to JS assets in production builds, addressing the primary concern of the critical TODO item.