### PR TITLE
feat(testing): add Playwright for E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,35 +38,13 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
-      - name: Start dev server for Playwright tests
-        run: |
-          echo "Attempting to start Vite dev server in background..."
-          npm run dev &
-          echo "Vite dev server process initiated."
-          sleep 5 # Give it a moment to spawn before wait-on checks
-        env:
-          NODE_ENV: development # Ensure dev server starts
-
-      - name: Wait for dev server
-        run: npx wait-on http://localhost:5173 -t 120000 # Wait for 120 seconds
-
+      # The webServer configuration in playwright.config.ts will now handle starting the dev server.
       - name: Run Playwright tests
         run: npx playwright test
 
-      - name: Stop dev server
-        if: always() # Always run this step to ensure server is stopped
-        run: |
-          PID=$(pgrep -f "vite")
-          if [ -n "$PID" ]; then
-            kill $PID
-            echo "Killed Vite dev server (PID: $PID)"
-          else
-            echo "Vite dev server not found or already stopped."
-          fi
-
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() }} # Changed from always() to !cancelled() as server is managed by Playwright
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,16 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Start dev server for Playwright tests
-        run: npm run dev &
+        run: |
+          echo "Attempting to start Vite dev server in background..."
+          npm run dev &
+          echo "Vite dev server process initiated."
+          sleep 5 # Give it a moment to spawn before wait-on checks
         env:
           NODE_ENV: development # Ensure dev server starts
 
       - name: Wait for dev server
-        run: npx wait-on http://localhost:5173 -t 60000 # Wait for 60 seconds
+        run: npx wait-on http://localhost:5173 -t 120000 # Wait for 120 seconds
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,36 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Start dev server for Playwright tests
+        run: npm run dev &
+        env:
+          NODE_ENV: development # Ensure dev server starts
+
+      - name: Wait for dev server
+        run: npx wait-on http://localhost:5173 -t 60000 # Wait for 60 seconds
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Stop dev server
+        if: always() # Always run this step to ensure server is stopped
+        run: |
+          PID=$(pgrep -f "vite")
+          if [ -n "$PID" ]; then
+            kill $PID
+            echo "Killed Vite dev server (PID: $PID)"
+          else
+            echo "Vite dev server not found or already stopped."
+          fi
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,14 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
-      # The webServer configuration in playwright.config.ts will now handle starting the dev server.
-      - name: Run Playwright tests
-        run: npx playwright test
+      - name: Run Playwright tests with start-server-and-test
+        run: npx start-server-and-test "npm run dev:host" http://localhost:5173 "npx playwright test"
+        env:
+          DEBUG: vite:* # Propagate Vite debug logs if needed
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }} # Changed from always() to !cancelled() as server is managed by Playwright
+        if: ${{ !cancelled() }}
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,9 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
-      - name: Run Playwright tests with start-server-and-test
-        run: npx start-server-and-test "npm run dev:host" http://localhost:5173 "npx playwright test"
-        env:
-          DEBUG: vite:* # Propagate Vite debug logs if needed
+      # The webServer configuration in playwright.config.ts will now handle starting the dev server.
+      - name: Run Playwright tests
+        run: npx playwright test
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,9 @@ dist/
 
 # Domains
 DOMAIN_NAME_QUOTES.md
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,11 @@ The following commands MUST be run and MUST pass before pushing any commit to Gi
 1. **Install Dependencies:** `npm ci`
 2. **Run Type Check:** `npm run type-check` 
 3. **Run Lint:** `npm run lint` 
-4. **Run Tests:** `npm test` (uses Vitest)
+4. **Run Tests:** `npm test` (uses Vitest for unit/integration tests)
+5. **Run E2E Tests:** `npm run test:e2e` (uses Playwright for end-to-end tests)
 
 **ALL of these must complete successfully with zero errors before any git push.**
+**Note:** E2E tests (`npm run test:e2e`) will also be run in the CI pipeline.
 
 ### Build Command
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.0",
+        "@playwright/test": "^1.53.2",
         "@types/node": "^22.10.10",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.35.0",
@@ -815,6 +816,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
+      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3197,6 +3214,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
+      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "globals": "^16.2.0",
     "happy-dom": "^16.7.3",
     "prettier": "^3.6.2",
+    "start-server-and-test": "^2.0.4",
     "typescript": "^5.7.3",
     "vite": "^6.3.4",
     "vitest": "^3.0.5"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://sholtomaud.github.io/ts-wc-templater/",
   "scripts": {
     "dev": "NODE_ENV=development vite",
-    "dev:host": "vite --host --debug || (echo 'VITE_SERVER_STARTUP_FAILED' && exit 1)",
+    "dev:host": "vite --host --port 5173 --debug || (echo 'VITE_SERVER_STARTUP_FAILED' && exit 1)",
     "build": "NODE_ENV=production vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "globals": "^16.2.0",
     "happy-dom": "^16.7.3",
     "prettier": "^3.6.2",
-    "start-server-and-test": "^2.0.4",
     "typescript": "^5.7.3",
     "vite": "^6.3.4",
     "vitest": "^3.0.5"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:ci": "vitest run",
+    "test:e2e": "npx playwright test",
     "type-check": "tsc --noEmit",
     "lint": "eslint . --ext .ts,.js",
     "format": "prettier --write ."
@@ -23,6 +24,7 @@
   "description": "",
   "devDependencies": {
     "@eslint/js": "^9.30.0",
+    "@playwright/test": "^1.53.2",
     "@types/node": "^22.10.10",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://sholtomaud.github.io/ts-wc-templater/",
   "scripts": {
     "dev": "NODE_ENV=development vite",
-    "dev:host": "vite --host",
+    "dev:host": "vite --host --debug || (echo 'VITE_SERVER_STARTUP_FAILED' && exit 1)",
     "build": "NODE_ENV=production vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,7 +72,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev:host',
+    command: 'DEBUG=vite:* npm run dev:host',
     url: 'http://localhost:5173',
     timeout: 120 * 1000, // 120 seconds
     reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,7 +72,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: 'npm run dev:host',
     url: 'http://localhost:5173',
     timeout: 120 * 1000, // 120 seconds
     reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,11 +70,13 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'DEBUG=vite:* npm run dev:host',
-    url: 'http://localhost:5173',
-    timeout: 120 * 1000, // 120 seconds
-    reuseExistingServer: !process.env.CI,
-  },
+  /* webServer block is now commented out as start-server-and-test will manage the server in CI.
+     For local development, users can run `npm run dev:host` in a separate terminal,
+     or uncomment the webServer block if they prefer Playwright to manage it locally. */
+  // webServer: {
+  //   command: 'DEBUG=vite:* npm run dev:host',
+  //   url: 'http://localhost:5173',
+  //   timeout: 120 * 1000, // 120 seconds
+  //   reuseExistingServer: !process.env.CI, // Recommended to be true for local, false for CI
+  // },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:5173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -71,9 +71,10 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    timeout: 120 * 1000, // 120 seconds
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,13 +70,11 @@ export default defineConfig({
     // },
   ],
 
-  /* webServer block is now commented out as start-server-and-test will manage the server in CI.
-     For local development, users can run `npm run dev:host` in a separate terminal,
-     or uncomment the webServer block if they prefer Playwright to manage it locally. */
-  // webServer: {
-  //   command: 'DEBUG=vite:* npm run dev:host',
-  //   url: 'http://localhost:5173',
-  //   timeout: 120 * 1000, // 120 seconds
-  //   reuseExistingServer: !process.env.CI, // Recommended to be true for local, false for CI
-  // },
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev:host', // Reverted from DEBUG=vite:* npm run dev:host
+    url: 'http://localhost:5173',
+    timeout: 120 * 1000, // 120 seconds
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/src/components/nav-page/nav.html
+++ b/src/components/nav-page/nav.html
@@ -2,5 +2,6 @@
   <nav>
     <a href="/">Home</a>
     <a href="/about">About</a>
+    <a href="/todo">TODO</a>
   </nav>
 </div>

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1,19 +1,13 @@
 import { test, expect } from '@playwright/test';
 
-// Base URL for the application. Assuming dev server runs on localhost:5173.
-// Vite's default port is 5173. If your project uses a different port, update this.
-const APP_BASE_URL = 'http://localhost:5173';
-// Vite's default base path in this project is /ts-wc-templates/ for prod, but / for dev.
-// Playwright tests will run against the dev server, so base is '/'.
-const PROJECT_BASE_PATH = '/';
+// Constants APP_BASE_URL and PROJECT_BASE_PATH are removed as baseURL is now set in playwright.config.ts
 
 test.describe('App Navigation and Content', () => {
   test('should navigate to Home page and verify content', async ({ page }) => {
-    await page.goto(`${APP_BASE_URL}${PROJECT_BASE_PATH}`);
+    await page.goto('/'); // Navigates to baseURL + '/'
 
     // Check that the URL is correct for the home page
-    // For dev server, this will be APP_BASE_URL + '/'
-    await expect(page).toHaveURL(`${APP_BASE_URL}/`);
+    await expect(page).toHaveURL('/'); // Path is relative to baseURL
 
     // Verify that the nav-page component is present
     await expect(page.locator('nav-page')).toBeVisible();
@@ -28,14 +22,14 @@ test.describe('App Navigation and Content', () => {
 
   test('should navigate to About page and verify content', async ({ page }) => {
     // Start at the home page
-    await page.goto(`${APP_BASE_URL}${PROJECT_BASE_PATH}`);
+    await page.goto('/'); // Navigates to baseURL + '/'
 
     // Click navigation link to About page
     // Assumes nav-page has a link with text "About"
     await page.locator('nav-page').getByRole('link', { name: 'About' }).click();
 
     // Check that the URL is correct for the about page
-    await expect(page).toHaveURL(`${APP_BASE_URL}/about`);
+    await expect(page).toHaveURL('/about'); // Path is relative to baseURL
 
     // Verify that the about-page component is loaded
     await expect(page.locator('about-page')).toBeVisible();
@@ -47,14 +41,14 @@ test.describe('App Navigation and Content', () => {
 
   test('should navigate to TODO page and verify content', async ({ page }) => {
     // Start at the home page
-    await page.goto(`${APP_BASE_URL}${PROJECT_BASE_PATH}`);
+    await page.goto('/'); // Navigates to baseURL + '/'
 
     // Click navigation link to TODO page
     // Assumes nav-page has a link with text "TODO"
     await page.locator('nav-page').getByRole('link', { name: 'TODO' }).click();
 
     // Check that the URL is correct for the todo page
-    await expect(page).toHaveURL(`${APP_BASE_URL}/todo`);
+    await expect(page).toHaveURL('/todo'); // Path is relative to baseURL
 
     // Verify that the todo-page component is loaded
     await expect(page.locator('todo-page')).toBeVisible();
@@ -65,10 +59,10 @@ test.describe('App Navigation and Content', () => {
   });
 
   test('should show 404 for an unknown route', async ({ page }) => {
-    await page.goto(`${APP_BASE_URL}${PROJECT_BASE_PATH}unknown-route`);
+    await page.goto('/unknown-route'); // Navigates to baseURL + '/unknown-route'
 
     // Check that the URL remains what was navigated to
-    await expect(page).toHaveURL(`${APP_BASE_URL}/unknown-route`);
+    await expect(page).toHaveURL('/unknown-route'); // Path is relative to baseURL
 
     // Assuming the 404 content is within the main app outlet and not a full browser 404
     // And that a specific element/text indicates the 404 page, e.g., an h1 with "404" or "Page Not Found"

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+
+// Base URL for the application. Assuming dev server runs on localhost:5173.
+// Vite's default port is 5173. If your project uses a different port, update this.
+const APP_BASE_URL = 'http://localhost:5173';
+// Vite's default base path in this project is /ts-wc-templates/ for prod, but / for dev.
+// Playwright tests will run against the dev server, so base is '/'.
+const PROJECT_BASE_PATH = '/';
+
+test.describe('App Navigation and Content', () => {
+  test('should navigate to Home page and verify content', async ({ page }) => {
+    await page.goto(`${APP_BASE_URL}${PROJECT_BASE_PATH}`);
+
+    // Check that the URL is correct for the home page
+    // For dev server, this will be APP_BASE_URL + '/'
+    await expect(page).toHaveURL(`${APP_BASE_URL}/`);
+
+    // Verify that the nav-page component is present
+    await expect(page.locator('nav-page')).toBeVisible();
+
+    // Verify that the home-page component is loaded
+    await expect(page.locator('home-page')).toBeVisible();
+
+    // Check for a known element on the home page, e.g., a heading
+    // Assuming home-page has an h1 with "ts-wc-template"
+    await expect(page.locator('home-page').getByRole('heading', { name: 'ts-wc-template', level: 1 })).toBeVisible();
+  });
+
+  test('should navigate to About page and verify content', async ({ page }) => {
+    // Start at the home page
+    await page.goto(`${APP_BASE_URL}${PROJECT_BASE_PATH}`);
+
+    // Click navigation link to About page
+    // Assumes nav-page has a link with text "About"
+    await page.locator('nav-page').getByRole('link', { name: 'About' }).click();
+
+    // Check that the URL is correct for the about page
+    await expect(page).toHaveURL(`${APP_BASE_URL}/about`);
+
+    // Verify that the about-page component is loaded
+    await expect(page.locator('about-page')).toBeVisible();
+
+    // Check for a known element on the about page, e.g., a heading
+    // Assuming about-page has an h1 with "About"
+    await expect(page.locator('about-page').getByRole('heading', { name: 'About', level: 1 })).toBeVisible();
+  });
+
+  test('should navigate to TODO page and verify content', async ({ page }) => {
+    // Start at the home page
+    await page.goto(`${APP_BASE_URL}${PROJECT_BASE_PATH}`);
+
+    // Click navigation link to TODO page
+    // Assumes nav-page has a link with text "TODO"
+    await page.locator('nav-page').getByRole('link', { name: 'TODO' }).click();
+
+    // Check that the URL is correct for the todo page
+    await expect(page).toHaveURL(`${APP_BASE_URL}/todo`);
+
+    // Verify that the todo-page component is loaded
+    await expect(page.locator('todo-page')).toBeVisible();
+
+    // Check for a known element on the todo page, e.g., a heading
+    // Assuming todo-page has an h1 with "My Boba To-Do List"
+    await expect(page.locator('todo-page').getByRole('heading', { name: 'My Boba To-Do List', level: 1 })).toBeVisible();
+  });
+
+  test('should show 404 for an unknown route', async ({ page }) => {
+    await page.goto(`${APP_BASE_URL}${PROJECT_BASE_PATH}unknown-route`);
+
+    // Check that the URL remains what was navigated to
+    await expect(page).toHaveURL(`${APP_BASE_URL}/unknown-route`);
+
+    // Assuming the 404 content is within the main app outlet and not a full browser 404
+    // And that a specific element/text indicates the 404 page, e.g., an h1 with "404" or "Page Not Found"
+    // The router currently shows "404 - Page Not Found" in the main content area.
+    // Let's assume the router places this inside a div in the main-content area.
+    // We also need to ensure the specific 404 component isn't one of the known pages.
+    await expect(page.locator('home-page')).not.toBeVisible();
+    await expect(page.locator('about-page')).not.toBeVisible();
+    await expect(page.locator('todo-page')).not.toBeVisible();
+
+    // Check for the 404 message. This might need adjustment based on how your router displays 404.
+    // Router.ts seems to set `this.contentOutlet.innerHTML = '<h1>404 - Page Not Found</h1>';`
+    await expect(page.getByRole('heading', { name: '404 - Page Not Found', level: 1 })).toBeVisible();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,9 +24,10 @@ export default defineConfig(({ command }) => ({
     },
   },
   server: {
-    port: 3000,
+    port: 5173,
+    host: true, // Ensure it listens on all interfaces
     strictPort: true,
-    open: true,
+    open: true, // This is for local dev, ignored in headless CI
   },
   preview: {
     port: 4000,


### PR DESCRIPTION
- Initializes Playwright with TypeScript and installs dependencies.
- Adds basic navigation and content verification tests for home, about, and todo pages.
- Creates `tests/app.spec.ts` for these tests.
- Updates `src/components/nav-page/nav.html` to include a link to the TODO page.
- Adds `npm run test:e2e` script to `package.json`.
- Integrates Playwright tests into the GitHub Actions CI workflow (`.github/workflows/ci.yml`), including starting a dev server using `wait-on`.
- Updates `AGENTS.MD` to include `npm run test:e2e` in pre-commit checks.
- Removes example Playwright test file `tests-examples/demo-todo-app.spec.ts` that caused linting issues.