### PR TITLE
fix(pages): fix about page and navigation links

### DIFF
--- a/src/components/about-page/about.html
+++ b/src/components/about-page/about.html
@@ -1,6 +1,12 @@
 <!-- about.component.html -->
-<app-nav></app-nav>
 <div class="about-container">
-  <h1>About</h1>
-  <p>About Page</p>
+  <h1 class="title">About This Project</h1>
+  <div class="content">
+    <p>
+      This repository is a template for building modern, fast, and modular web applications using TypeScript and Web Components, powered by Vite.
+    </p>
+    <p>
+      It features a lightweight client-side router, a component-based architecture with a base class for easy component creation, and a development environment optimized with Vite. The goal is to provide a clean, intuitive, and "bubbly" developer experience.
+    </p>
+  </div>
 </div>

--- a/src/components/nav-page/nav.html
+++ b/src/components/nav-page/nav.html
@@ -2,5 +2,6 @@
   <nav>
     <a href="/">Home</a>
     <a href="/about">About</a>
+    <a href="/todo">Todo</a>
   </nav>
 </div>


### PR DESCRIPTION
- Removes redundant `<app-nav>` from the About page component to prevent a nested navigation bar.
- Updates the content of the About page with a proper project description.
- Adds a "Todo" link to the main navigation bar to make the example app discoverable.
- Verifies that the navigation component correctly uses the client-side router for SPA-style navigation.