### PR TITLE
chore(project): rebrand to Boba, fix content and links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - Instructions for AI Agents
 
-Welcome, AI Agent! This file provides guidance for working with the `ts-wc-templates` repository.
+Welcome, AI Agent! This file provides guidance for working with the `Boba` repository.
 
 ## 1. Project Overview
 
@@ -171,16 +171,16 @@ git rebase main
 
 ## 5. Deployment (GitHub Pages)
 
-This project is configured for deployment to GitHub Pages under a repository-named subdirectory (e.g., `https://<username>.github.io/ts-wc-templates/`).
+This project is configured for deployment to GitHub Pages under a repository-named subdirectory (e.g., `https://<username>.github.io/boba-templater/`).
 
-*   **Base Path:** The `vite.config.ts` file sets `base: '/ts-wc-templates/'` during production builds (`command === 'build'`). This ensures that `import.meta.env.BASE_URL` is correctly set to `/ts-wc-templates/`, and all asset paths in the built `index.html` are prefixed accordingly.
+*   **Base Path:** The `vite.config.ts` file sets `base: '/boba-templater/'` during production builds (`command === 'build'`). This ensures that `import.meta.env.BASE_URL` is correctly set to `/boba-templater/`, and all asset paths in the built `index.html` are prefixed accordingly.
 *   **SPA Routing (404.html Strategy):** To support deep linking in the SPA on GitHub Pages, the `.github/workflows/deploy.yml` workflow includes a step: `cp dist/index.html dist/404.html`. This means GitHub Pages will serve the application's main `index.html` file for any path it doesn't directly recognize, allowing the client-side router to handle the specific route.
 
 ## 6. Routing
 
 *   Client-side routing is handled by the `Router` class in `src/core/router/router.ts`.
 *   Routes are defined and registered in `src/main.ts` using `Router.getInstance().registerRoute({...});`.
-*   The router uses `import.meta.env.BASE_URL` (provided by Vite, see "Deployment" section) to correctly determine the application-specific path from `window.location.pathname`. For example, if `BASE_URL` is `/ts-wc-templates/` and `window.location.pathname` is `/ts-wc-templates/about`, the router will correctly identify the application path as `/about`.
+*   The router uses `import.meta.env.BASE_URL` (provided by Vite, see "Deployment" section) to correctly determine the application-specific path from `window.location.pathname`. For example, if `BASE_URL` is `/boba-templater/` and `window.location.pathname` is `/boba-templater/about`, the router will correctly identify the application path as `/about`.
 
 ## 7. Component Structure
 
@@ -321,3 +321,25 @@ As an AI agent working with this codebase, embody these principles:
 ---
 
 **Remember:** The goal is continuous improvement while maintaining stability, security, and reliability. Every change should make the development experience better for future AI agents and human developers.
+
+## PROPOSED AGENTS.MD UPDATE
+
+### Reason for Update:
+The project has been rebranded from `ts-wc-templates` to `Boba`. This update reflects the new naming in the agent instructions to avoid confusion.
+
+### Section(s) to Modify:
+- Section 1: Project Overview
+- Section 5: Deployment (GitHub Pages)
+- Section 6: Routing
+
+### Proposed Changes:
+Replaced all instances of `ts-wc-templates` with `Boba` or `boba-templater` where appropriate to reflect the new project name.
+
+### Security Impact Assessment (if applicable):
+N/A. This is a documentation and branding change.
+
+### Expected Benefits:
+Instructions are now consistent with the rest of the codebase, reducing confusion for AI agents.
+
+### Testing/Validation:
+The changes can be validated by confirming that the instructions align with the updated file names and configurations in `package.json` and `vite.config.ts`.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ This system allows for efficient code splitting and on-demand loading of compone
 This template aims to provide a solid, simple foundation. Future enhancements will focus on improving developer experience and robustness, while maintaining this core philosophy.
 
 - **CLI Tool for Code Generation:**
-  A key planned enhancement is a Node.js CLI tool (e.g., `npx ts-wc-cli generate component <name>`) to scaffold new components, services, and manage routes. This will enforce conventions and speed up development.
+  A key planned enhancement is a Node.js CLI tool (e.g., `npx boba-cli generate component <name>`) to scaffold new components, services, and manage routes. This will enforce conventions and speed up development.
   - The CLI could also generate/maintain structured "context files" (e.g., `project-manifest.json`) describing the project's layout. This "MCP-Lite" (Model Context Protocol - Lite) approach could provide essential context for external tools or AI-assisted development, facilitating more advanced integrations in the future without overburdening the core template.
 
 - **PWA Capabilities:** Integrating PWA features (via `vite-plugin-pwa` or similar) to enable offline functionality and installability is a high-value next step.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
-# TODO List for ts-wc-template Improvements
+# TODO List for Boba Improvements
 
-This list tracks potential improvements and fixes for the `ts-wc-template` repository. Items are categorized and prioritized. The overall philosophy is to maintain simplicity in the core template while enhancing developer experience and robustness.
+This list tracks potential improvements and fixes for the `Boba` repository. Items are categorized and prioritized. The overall philosophy is to maintain simplicity in the core template while enhancing developer experience and robustness.
 
 ## Immediate Priorities (Core Template Health)
 
@@ -41,7 +41,7 @@ This list tracks potential improvements and fixes for the `ts-wc-template` repos
 
 
 - **`[IDEA/HIGH]`** `[ ]` Design and Implement a Core CLI Tool:
-  - Scope out essential features for a Node.js CLI (e.g., `ts-wc-cli` or similar).
+  - Scope out essential features for a Node.js CLI (e.g., `boba-cli` or similar).
   - **Core commands:**
     - `generate component <component-name>`: Scaffolds component `.ts`, `.html`, `.css`, and `.test.ts` files adhering to template conventions.
     - `generate service <service-name>`: Scaffolds a service file in `src/services/`.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "ts-wc-templater",
+  "name": "boba-templater",
   "version": "1.0.0",
   "type": "module",
   "main": "./src/main.ts",
-  "homepage": "https://sholtomaud.github.io/ts-wc-templater/",
+  "homepage": "https://sholtomaud.github.io/boba-templater/",
   "scripts": {
     "dev": "NODE_ENV=development vite",
     "dev:host": "vite --host",

--- a/src/components/home-page/home.html
+++ b/src/components/home-page/home.html
@@ -1,8 +1,8 @@
 <div class="home-container">
   <header class="main-header">
-    <h1>ts-wc-template</h1>
+    <h1>Boba</h1>
     <p>A modern starting point for building TypeScript Web Components with Vite.</p>
-    <a href="/todo" class="cta-button">
+    <a href="todo" class="cta-button">
       View To-Do List Demo
     </a>
   </header>
@@ -15,7 +15,6 @@
         <li>TypeScript Ready</li>
         <li>Web Component Based</li>
         <li>Simple Routing</li>
-        <li>Tailwind CSS Integrated</li>
         <li>Unit Testing with Vitest</li>
       </ul>
     </div>
@@ -25,18 +24,15 @@
         Clone the repository and start building your next web application:
       </p>
       <code class="code-block">
-        git clone https://github.com/sholtomaud/ts-wc-template.git <br>
-        cd ts-wc-template <br>
+        git clone https://github.com/sholtomaud/boba-templater.git <br>
+        cd boba-templater <br>
         npm install <br>
         npm run dev
       </code>
-      <p>
-        Explore the <a href="https://github.com/sholtomaud/ts-wc-template" target="_blank" rel="noopener noreferrer" class="docs-link">documentation on GitHub</a>.
-      </p>
     </div>
   </main>
 
   <footer class="main-footer">
-    <p>&copy; 2024 ts-wc-template. Built with Boba.</p>
+    <p>&copy; 2024 Boba. Built with Boba.</p>
   </footer>
 </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import componentManifest from './vite-plugin-component-manifest';
 
 export default defineConfig(({ command }) => ({
-  base: command === 'build' ? '/ts-wc-templates/' : '/',
+  base: command === 'build' ? '/boba-templater/' : '/',
   plugins: [componentManifest()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
This commit addresses several issues to align the project with its new "Boba" identity and fix content-related problems.

- **Branding:** Replaced all instances of `ts-wc-templates` and `ts-wc-templater` with `Boba` and `boba-templater` across the entire project, including in `package.json`, `vite.config.ts`, `README.md`, `TODO.md`, and `AGENTS.md`.

- **Homepage Fixes:**
  - The "View To-Do List Demo" link was changed from an absolute path (`/todo`) to a relative one (`todo`) to ensure it works correctly on GitHub Pages deployments.
  - Removed the list item mentioning "Tailwind CSS Integrated" as the feature is not present.
  - Removed the paragraph containing the broken "documentation on GitHub" link.

- **Clarity:** The changes also align with the clarification provided to you that Playwright tests are a future to-do item, not an existing, broken feature.