### PR TITLE
Fix GitHub Pages asset 404s and add regression test

### DIFF
--- a/e2e/assets.spec.js
+++ b/e2e/assets.spec.js
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test('no absolute asset paths in index.html', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  const { absoluteLinks, absoluteScripts } = await page.evaluate(() => {
+    const links = Array.from(document.querySelectorAll('link[href]'));
+    const absoluteLinks = links
+      .map(link => link.getAttribute('href'))
+      .filter(href => href && href.startsWith('/') && !href.startsWith('//'));
+
+    const scripts = Array.from(document.querySelectorAll('script[src]'));
+    const absoluteScripts = scripts
+      .map(script => script.getAttribute('src'))
+      .filter(src => src && src.startsWith('/') && !src.startsWith('//') && !src.startsWith('/@vite/'));
+
+    return { absoluteLinks, absoluteScripts };
+  });
+
+  if (absoluteLinks.length > 0 || absoluteScripts.length > 0) {
+     console.log('Absolute links found:', absoluteLinks);
+     console.log('Absolute scripts found:', absoluteScripts);
+  }
+
+  expect(absoluteLinks, `Found absolute links: ${absoluteLinks}`).toEqual([]);
+  expect(absoluteScripts, `Found absolute scripts: ${absoluteScripts}`).toEqual([]);
+});

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Boba App</title>
-    <link href="/src/styles/global.css" rel="stylesheet" />
-    <script type="module" src="/src/main.ts"></script>
+    <link href="src/styles/global.css" rel="stylesheet" />
+    <script type="module" src="src/main.ts"></script>
   </head>
   <body>
     <app-nav></app-nav>

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,10 @@ import './components/about-page/about-page.ts';
 import './components/todo-page/todo-page.ts';
 
 // Setup BASE_URL for the router
-window.BOBA_BASE_URL = '/';
+const isGitHubPages = window.location.hostname.endsWith('.github.io');
+const pathSegments = window.location.pathname.split('/');
+const repoName = isGitHubPages && pathSegments.length > 1 && pathSegments[1] ? pathSegments[1] : null;
+(window as any).BOBA_BASE_URL = repoName ? `/${repoName}/` : '/';
 
 function getInitialAppPath() {
   const pathname = window.location.pathname;

--- a/template/index.html
+++ b/template/index.html
@@ -8,8 +8,8 @@
       content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws:;"
     />
     <title>Boba App</title>
-    <link href="/src/styles/global.css" rel="stylesheet" />
-    <script type="module" src="/src/main.ts"></script>
+    <link href="src/styles/global.css" rel="stylesheet" />
+    <script type="module" src="src/main.ts"></script>
   </head>
   <body>
     <app-nav></app-nav>

--- a/template/src/main.ts
+++ b/template/src/main.ts
@@ -7,7 +7,10 @@ import './components/nav-page/nav-page.ts';
 import './components/docs-page/docs-page.ts';
 
 // Setup BASE_URL for the router
-window.BOBA_BASE_URL = '/';
+const isGitHubPages = window.location.hostname.endsWith('.github.io');
+const pathSegments = window.location.pathname.split('/');
+const repoName = isGitHubPages && pathSegments.length > 1 && pathSegments[1] ? pathSegments[1] : null;
+(window as any).BOBA_BASE_URL = repoName ? `/${repoName}/` : '/';
 
 function getInitialAppPath() {
   const pathname = window.location.pathname;


### PR DESCRIPTION
This PR fixes the 404 errors reported when deploying to GitHub Pages (which often hosts project sites in a subpath like `/repo-name/`).

Key changes:
1.  **Relative Asset Paths**: Updated `index.html` and `template/index.html` to use relative paths for `global.css` and `main.ts`. This ensures they resolve correctly regardless of whether the app is hosted at the root or a subpath.
2.  **Dynamic Base URL Detection**: Updated the router initialization in `main.ts` to automatically detect if it's running on GitHub Pages and extract the repository name to use as `BOBA_BASE_URL`. This fixes client-side routing issues on project sites.
3.  **Regression Testing**: Added a new Playwright test `e2e/assets.spec.js` that scans the rendered HTML for any absolute paths starting with `/` (excluding Vite's internal client scripts), ensuring future changes don't re-introduce this issue.

Verified with `npm test` and `npx playwright test`. Visual verification confirmed the app still functions correctly in local development.

Fixes #74

---
*PR created automatically by Jules for task [8018756632381377285](https://jules.google.com/task/8018756632381377285) started by @sholtomaud*