### PR TITLE
Fix template build failures in patching workflow

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws:;"
+    />
+    <title>Boba App</title>
+    <script type="module" src="src/main.ts"></script>
+  </head>
+  <body>
+    <app-nav></app-nav>
+    <div id="router-outlet"></div>
+  </body>
+</html>

--- a/template/src/styles/global.css
+++ b/template/src/styles/global.css
@@ -1,0 +1,15 @@
+@import "tailwindcss";
+
+:root {
+  /* Boba Color Variables */
+  --boba-primary: #111827; /* Gray 900 */
+  --boba-secondary: #4b5563; /* Gray 600 */
+  --boba-accent: #3b82f6; /* Blue 500 */
+  --boba-bg: #f9fafb; /* Gray 50 */
+  --boba-text: #1f2937; /* Gray 800 */
+}
+
+body {
+  background-color: var(--boba-bg);
+  color: var(--boba-text);
+}


### PR DESCRIPTION
Added `template/index.html` and `template/src/styles/global.css` to fix the missing entry module error during the template production build process. This prevents the scheduled patching workflow from failing.

Fixes #89

---
*PR created automatically by Jules for task [31969679964916603](https://jules.google.com/task/31969679964916603) started by @sholtomaud*