### PR TITLE
Upgrade Playwright to v1.62.0 to fix E2E test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.61.1-noble
+    container: mcr.microsoft.com/playwright:v1.62.0-noble
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   test-and-prepare:
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.61.1-noble
+    container: mcr.microsoft.com/playwright:v1.62.0-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/patching.yml
+++ b/.github/workflows/patching.yml
@@ -9,7 +9,7 @@ jobs:
   patch-and-test:
     name: Patch & Test Dependencies
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.61.1-noble
+    container: mcr.microsoft.com/playwright:v1.62.0-noble
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.61.1-noble
+    container: mcr.microsoft.com/playwright:v1.62.0-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@ ENV NODE_OPTIONS=--max-old-space-size=3072
 
 # Install Playwright system dependencies and Chromium browser
 RUN apt-get update && \
-    npx -y playwright@1.61.1 install chromium --with-deps && \
+    npx -y playwright@1.62.0 install chromium --with-deps && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.2",
         "@types/node": "^26.1.1",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
@@ -22,7 +22,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.7.0",
-        "playwright": "^1.61.1",
+        "playwright": "^1.62.0",
         "postcss": "^8.5.25",
         "serve": "^14.2.6",
         "tailwindcss": "^4.3.2",
@@ -353,19 +353,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3004,35 +3004,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.0",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
@@ -31,7 +31,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.7.0",
-    "playwright": "^1.61.1",
+    "playwright": "^1.62.0",
     "postcss": "^8.5.25",
     "serve": "^14.2.6",
     "tailwindcss": "^4.3.2",

--- a/template/package.json
+++ b/template/package.json
@@ -14,12 +14,12 @@
     "e2e": "npx playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.0",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/node": "^26.1.1",
     "autoprefixer": "^10.5.2",
     "eslint": "^10.6.0",
-    "playwright": "^1.61.1",
+    "playwright": "^1.62.0",
     "postcss": "^8.5.16",
     "serve": "^14.2.6",
     "tailwindcss": "^4.3.2",


### PR DESCRIPTION
This pull request upgrades Playwright to version 1.62.0 across the entire repository to resolve E2E execution failures resulting from a version mismatch between the installed dependencies and cached/Docker browsers. All root workflows, Containerfile, and package.json configurations have been updated. Testing confirms that all E2E and unit tests pass successfully.

Fixes #92

---
*PR created automatically by Jules for task [16762625327568160515](https://jules.google.com/task/16762625327568160515) started by @sholtomaud*