### PR TITLE
Add SVG favicon and brand icon for Boba

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws:;"
     />
     <title>Boba App</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <script type="module" src="src/main.ts"></script>
   </head>
   <body>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <linearGradient id="boba-bg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3B82F6"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background squircle -->
+  <rect width="32" height="32" rx="7" fill="url(#boba-bg)"/>
+
+  <!-- Straw -->
+  <path d="M19 4L14.5 14" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Cup Lid/Rim -->
+  <path d="M8.5 13H23.5" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Cup Body -->
+  <path d="M9.5 13.5L11.2 25C11.35 26.1 12.25 27 13.35 27H18.65C19.75 27 20.65 26.1 20.8 25L22.5 13.5" fill="#FFFFFF" fill-opacity="0.15" stroke="#FFFFFF" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+
+  <!-- Tapioca Pearls (Boba) -->
+  <circle cx="13.2" cy="23.2" r="1.6" fill="#0F172A"/>
+  <circle cx="16" cy="24" r="1.6" fill="#0F172A"/>
+  <circle cx="18.8" cy="23.2" r="1.6" fill="#0F172A"/>
+  <circle cx="14.6" cy="20.5" r="1.5" fill="#0F172A"/>
+  <circle cx="17.4" cy="20.5" r="1.5" fill="#0F172A"/>
+
+  <!-- Pearl Highlights -->
+  <circle cx="12.7" cy="22.7" r="0.5" fill="#FFFFFF"/>
+  <circle cx="15.5" cy="23.5" r="0.5" fill="#FFFFFF"/>
+  <circle cx="18.3" cy="22.7" r="0.5" fill="#FFFFFF"/>
+  <circle cx="14.1" cy="20" r="0.4" fill="#FFFFFF"/>
+  <circle cx="16.9" cy="20" r="0.4" fill="#FFFFFF"/>
+</svg>

--- a/src/components/home-page/home-page.html
+++ b/src/components/home-page/home-page.html
@@ -1,6 +1,30 @@
 <div class="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-6 text-center">
   <div class="max-w-4xl w-full">
-    <header class="mb-12">
+    <header class="mb-12 flex flex-col items-center">
+      <div class="w-20 h-20 mb-4 drop-shadow-xl transition-transform hover:scale-105">
+        <svg class="w-full h-full" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="boba-hero-bg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#3B82F6"/>
+              <stop offset="100%" stop-color="#6366F1"/>
+            </linearGradient>
+          </defs>
+          <rect width="32" height="32" rx="7" fill="url(#boba-hero-bg)"/>
+          <path d="M19 4L14.5 14" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+          <path d="M8.5 13H23.5" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+          <path d="M9.5 13.5L11.2 25C11.35 26.1 12.25 27 13.35 27H18.65C19.75 27 20.65 26.1 20.8 25L22.5 13.5" fill="#FFFFFF" fill-opacity="0.15" stroke="#FFFFFF" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+          <circle cx="13.2" cy="23.2" r="1.6" fill="#0F172A"/>
+          <circle cx="16" cy="24" r="1.6" fill="#0F172A"/>
+          <circle cx="18.8" cy="23.2" r="1.6" fill="#0F172A"/>
+          <circle cx="14.6" cy="20.5" r="1.5" fill="#0F172A"/>
+          <circle cx="17.4" cy="20.5" r="1.5" fill="#0F172A"/>
+          <circle cx="12.7" cy="22.7" r="0.5" fill="#FFFFFF"/>
+          <circle cx="15.5" cy="23.5" r="0.5" fill="#FFFFFF"/>
+          <circle cx="18.3" cy="22.7" r="0.5" fill="#FFFFFF"/>
+          <circle cx="14.1" cy="20" r="0.4" fill="#FFFFFF"/>
+          <circle cx="16.9" cy="20" r="0.4" fill="#FFFFFF"/>
+        </svg>
+      </div>
       <h1 class="text-7xl font-extrabold text-gray-900 mb-4 tracking-tighter bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-indigo-600">Boba</h1>
       <p class="text-2xl text-gray-600 font-medium max-w-2xl mx-auto leading-relaxed">A minimalist framework for the modern web. Ultra-fast, zero-build, and purely standards-based.</p>
     </header>

--- a/src/components/nav-page/nav-page.html
+++ b/src/components/nav-page/nav-page.html
@@ -1,7 +1,31 @@
 <nav class="bg-gray-900 text-white p-4 shadow-md">
   <div class="container mx-auto flex justify-between items-center px-4">
     <div class="flex items-center space-x-6">
-      <a href="/" class="text-2xl font-bold tracking-tight hover:text-blue-400 transition-colors">Boba</a>
+      <a href="/" class="flex items-center space-x-2.5 text-2xl font-bold tracking-tight hover:text-blue-400 transition-colors">
+        <svg class="w-8 h-8 rounded-lg shrink-0" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="boba-nav-bg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#3B82F6"/>
+              <stop offset="100%" stop-color="#6366F1"/>
+            </linearGradient>
+          </defs>
+          <rect width="32" height="32" rx="7" fill="url(#boba-nav-bg)"/>
+          <path d="M19 4L14.5 14" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+          <path d="M8.5 13H23.5" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+          <path d="M9.5 13.5L11.2 25C11.35 26.1 12.25 27 13.35 27H18.65C19.75 27 20.65 26.1 20.8 25L22.5 13.5" fill="#FFFFFF" fill-opacity="0.15" stroke="#FFFFFF" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+          <circle cx="13.2" cy="23.2" r="1.6" fill="#0F172A"/>
+          <circle cx="16" cy="24" r="1.6" fill="#0F172A"/>
+          <circle cx="18.8" cy="23.2" r="1.6" fill="#0F172A"/>
+          <circle cx="14.6" cy="20.5" r="1.5" fill="#0F172A"/>
+          <circle cx="17.4" cy="20.5" r="1.5" fill="#0F172A"/>
+          <circle cx="12.7" cy="22.7" r="0.5" fill="#FFFFFF"/>
+          <circle cx="15.5" cy="23.5" r="0.5" fill="#FFFFFF"/>
+          <circle cx="18.3" cy="22.7" r="0.5" fill="#FFFFFF"/>
+          <circle cx="14.1" cy="20" r="0.4" fill="#FFFFFF"/>
+          <circle cx="16.9" cy="20" r="0.4" fill="#FFFFFF"/>
+        </svg>
+        <span>Boba</span>
+      </a>
       <ul class="flex space-x-6 text-sm font-medium">
         <li><a href="/" class="hover:text-blue-400 transition-colors">Home</a></li>
         <li><a href="/docs" class="hover:text-blue-400 transition-colors">Docs</a></li>

--- a/template/index.html
+++ b/template/index.html
@@ -8,6 +8,7 @@
       content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws:;"
     />
     <title>Boba App</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <script type="module" src="src/main.ts"></script>
   </head>
   <body>

--- a/template/public/favicon.svg
+++ b/template/public/favicon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <linearGradient id="boba-bg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3B82F6"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background squircle -->
+  <rect width="32" height="32" rx="7" fill="url(#boba-bg)"/>
+
+  <!-- Straw -->
+  <path d="M19 4L14.5 14" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Cup Lid/Rim -->
+  <path d="M8.5 13H23.5" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Cup Body -->
+  <path d="M9.5 13.5L11.2 25C11.35 26.1 12.25 27 13.35 27H18.65C19.75 27 20.65 26.1 20.8 25L22.5 13.5" fill="#FFFFFF" fill-opacity="0.15" stroke="#FFFFFF" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+
+  <!-- Tapioca Pearls (Boba) -->
+  <circle cx="13.2" cy="23.2" r="1.6" fill="#0F172A"/>
+  <circle cx="16" cy="24" r="1.6" fill="#0F172A"/>
+  <circle cx="18.8" cy="23.2" r="1.6" fill="#0F172A"/>
+  <circle cx="14.6" cy="20.5" r="1.5" fill="#0F172A"/>
+  <circle cx="17.4" cy="20.5" r="1.5" fill="#0F172A"/>
+
+  <!-- Pearl Highlights -->
+  <circle cx="12.7" cy="22.7" r="0.5" fill="#FFFFFF"/>
+  <circle cx="15.5" cy="23.5" r="0.5" fill="#FFFFFF"/>
+  <circle cx="18.3" cy="22.7" r="0.5" fill="#FFFFFF"/>
+  <circle cx="14.1" cy="20" r="0.4" fill="#FFFFFF"/>
+  <circle cx="16.9" cy="20" r="0.4" fill="#FFFFFF"/>
+</svg>

--- a/template/src/components/home-page/home-page.html
+++ b/template/src/components/home-page/home-page.html
@@ -1,6 +1,30 @@
 <div class="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-6 text-center">
   <div class="max-w-4xl w-full">
-    <header class="mb-12">
+    <header class="mb-12 flex flex-col items-center">
+      <div class="w-20 h-20 mb-4 drop-shadow-xl transition-transform hover:scale-105">
+        <svg class="w-full h-full" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="boba-tmpl-hero-bg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#3B82F6"/>
+              <stop offset="100%" stop-color="#6366F1"/>
+            </linearGradient>
+          </defs>
+          <rect width="32" height="32" rx="7" fill="url(#boba-tmpl-hero-bg)"/>
+          <path d="M19 4L14.5 14" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+          <path d="M8.5 13H23.5" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+          <path d="M9.5 13.5L11.2 25C11.35 26.1 12.25 27 13.35 27H18.65C19.75 27 20.65 26.1 20.8 25L22.5 13.5" fill="#FFFFFF" fill-opacity="0.15" stroke="#FFFFFF" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+          <circle cx="13.2" cy="23.2" r="1.6" fill="#0F172A"/>
+          <circle cx="16" cy="24" r="1.6" fill="#0F172A"/>
+          <circle cx="18.8" cy="23.2" r="1.6" fill="#0F172A"/>
+          <circle cx="14.6" cy="20.5" r="1.5" fill="#0F172A"/>
+          <circle cx="17.4" cy="20.5" r="1.5" fill="#0F172A"/>
+          <circle cx="12.7" cy="22.7" r="0.5" fill="#FFFFFF"/>
+          <circle cx="15.5" cy="23.5" r="0.5" fill="#FFFFFF"/>
+          <circle cx="18.3" cy="22.7" r="0.5" fill="#FFFFFF"/>
+          <circle cx="14.1" cy="20" r="0.4" fill="#FFFFFF"/>
+          <circle cx="16.9" cy="20" r="0.4" fill="#FFFFFF"/>
+        </svg>
+      </div>
       <h1 class="text-7xl font-extrabold text-gray-900 mb-4 tracking-tighter bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-indigo-600">Boba</h1>
       <p class="text-2xl text-gray-600 font-medium max-w-2xl mx-auto leading-relaxed">Welcome to your new Boba application!</p>
     </header>

--- a/template/src/components/nav-page/nav-page.html
+++ b/template/src/components/nav-page/nav-page.html
@@ -1,7 +1,31 @@
 <nav class="bg-gray-900 text-white p-4 shadow-md">
   <div class="container mx-auto flex justify-between items-center px-4">
     <div class="flex items-center space-x-6">
-      <a href="/" class="text-2xl font-bold tracking-tight hover:text-blue-400 transition-colors">Boba</a>
+      <a href="/" class="flex items-center space-x-2.5 text-2xl font-bold tracking-tight hover:text-blue-400 transition-colors">
+        <svg class="w-8 h-8 rounded-lg shrink-0" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="boba-tmpl-nav-bg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#3B82F6"/>
+              <stop offset="100%" stop-color="#6366F1"/>
+            </linearGradient>
+          </defs>
+          <rect width="32" height="32" rx="7" fill="url(#boba-tmpl-nav-bg)"/>
+          <path d="M19 4L14.5 14" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+          <path d="M8.5 13H23.5" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+          <path d="M9.5 13.5L11.2 25C11.35 26.1 12.25 27 13.35 27H18.65C19.75 27 20.65 26.1 20.8 25L22.5 13.5" fill="#FFFFFF" fill-opacity="0.15" stroke="#FFFFFF" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+          <circle cx="13.2" cy="23.2" r="1.6" fill="#0F172A"/>
+          <circle cx="16" cy="24" r="1.6" fill="#0F172A"/>
+          <circle cx="18.8" cy="23.2" r="1.6" fill="#0F172A"/>
+          <circle cx="14.6" cy="20.5" r="1.5" fill="#0F172A"/>
+          <circle cx="17.4" cy="20.5" r="1.5" fill="#0F172A"/>
+          <circle cx="12.7" cy="22.7" r="0.5" fill="#FFFFFF"/>
+          <circle cx="15.5" cy="23.5" r="0.5" fill="#FFFFFF"/>
+          <circle cx="18.3" cy="22.7" r="0.5" fill="#FFFFFF"/>
+          <circle cx="14.1" cy="20" r="0.4" fill="#FFFFFF"/>
+          <circle cx="16.9" cy="20" r="0.4" fill="#FFFFFF"/>
+        </svg>
+        <span>Boba</span>
+      </a>
       <ul class="flex space-x-6 text-sm font-medium">
         <li><a href="/" class="hover:text-blue-400 transition-colors">Home</a></li>
         <li><a href="/docs" class="hover:text-blue-400 transition-colors">Docs</a></li>


### PR DESCRIPTION
Added a minimal, modern SVG favicon and brand icon for Boba. Created public/favicon.svg and template/public/favicon.svg, linked the favicon in index.html and template/index.html, and integrated the SVG brand icon into the navigation header and landing page hero section.

Fixes #96

---
*PR created automatically by Jules for task [12711801534067285160](https://jules.google.com/task/12711801534067285160) started by @sholtomaud*