### PR TITLE
Remove Home nav link, fix Get Started routing, and update to muted minimal design

### DIFF
--- a/src/components/docs-page/docs-page.html
+++ b/src/components/docs-page/docs-page.html
@@ -9,33 +9,41 @@
             Documentation Overview
           </h3>
           <nav class="space-y-1 text-sm font-medium">
-            <a href="#intro" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-              <span class="w-1.5 h-1.5 rounded-full bg-sky-500"></span>
+            <a href="#intro" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
               Getting Started
             </a>
-            <a href="#components" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-              <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-              Web Components
+            <a href="#structure" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
+              Project Structure
             </a>
-            <a href="#routing" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-              <span class="w-1.5 h-1.5 rounded-full bg-purple-500"></span>
-              Smart Routing
+            <a href="#components" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
+              BaseComponent & Light DOM
             </a>
-            <a href="#state" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-              <span class="w-1.5 h-1.5 rounded-full bg-amber-500"></span>
+            <a href="#routing" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
+              Smart Client Routing
+            </a>
+            <a href="#state" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
               State Management
+            </a>
+            <a href="#deployment" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
+              Build & Production Deployment
             </a>
           </nav>
         </div>
 
-        <div class="p-4 rounded-xl bg-sky-50 dark:bg-sky-950/40 border border-sky-200 dark:border-sky-800/60 text-xs text-sky-800 dark:text-sky-200">
-          <div class="font-bold mb-1 flex items-center gap-1.5">
-            <svg class="w-4 h-4 text-sky-600 dark:text-sky-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <div class="p-4 rounded-xl bg-slate-100 dark:bg-slate-900/60 border border-slate-200 dark:border-slate-800 text-xs text-slate-800 dark:text-slate-300">
+          <div class="font-bold mb-1 flex items-center gap-1.5 text-slate-900 dark:text-slate-100">
+            <svg class="w-4 h-4 text-slate-600 dark:text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            Pro Tip
+            Zero-Build Workflow
           </div>
-          Boba runs natively on Node 25+ without any build step required for local dev.
+          Boba runs natively on Node 25+ using native TypeScript type stripping without transpilation overhead.
         </div>
       </div>
     </aside>
@@ -49,118 +57,166 @@
           Documentation
         </h1>
         <p class="text-lg text-slate-600 dark:text-slate-300 leading-relaxed font-normal">
-          Everything you need to know about building enterprise-grade, minimalist web applications with Boba.
+          Comprehensive guide to building minimal, modern, enterprise-grade web applications using Boba.
         </p>
       </header>
 
-      <!-- Section 1: Intro -->
+      <!-- Section 1: Quickstart -->
       <section id="intro" class="mb-14 scroll-mt-24">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
-          <span class="w-8 h-8 rounded-lg bg-sky-100 dark:bg-sky-950 text-sky-600 dark:text-sky-400 flex items-center justify-center text-sm font-extrabold">1</span>
-          Getting Started
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">1</span>
+          Getting Started & Scaffolding
         </h2>
 
         <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
-          Boba is a zero-build framework leveraging browser standards (Web Components, Light DOM styling, ES Modules) and Node.js v25+ native type stripping for ultra-fast performance.
+          Boba provides a lightweight scaffolding CLI to generate clean, production-ready applications powered by browser standards, native Web Components, and Vite.
         </p>
 
-        <!-- Command Box -->
         <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs sm:text-sm border border-slate-800 shadow-sm mb-6 overflow-x-auto">
-          <div class="text-slate-500 mb-2"># Scaffold a new Boba application</div>
-          <div class="text-sky-400 mb-3">npx github:sholtomaud/boba my-boba-app</div>
+          <div class="text-slate-500 mb-2"># Scaffold a new Boba project</div>
+          <div class="text-slate-200 mb-3">npx github:sholtomaud/boba my-app</div>
           <div class="text-slate-500 mb-2"># Navigate and install dependencies</div>
-          <div class="text-slate-200 mb-3">cd my-boba-app && npm install</div>
-          <div class="text-slate-500 mb-2"># Launch live dev server</div>
-          <div class="text-emerald-400">npm start</div>
+          <div class="text-slate-200 mb-3">cd my-app && npm install</div>
+          <div class="text-slate-500 mb-2"># Start Vite development server</div>
+          <div class="text-slate-200">npm start</div>
         </div>
 
-        <!-- VitePress-style Callout Note -->
-        <div class="p-4 rounded-xl bg-slate-50 dark:bg-slate-900/80 border-l-4 border-sky-500 text-sm text-slate-700 dark:text-slate-300">
-          <span class="font-bold text-slate-900 dark:text-slate-100">Note:</span> Running <code class="px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-800 font-mono text-xs">npm start</code> starts Vite dev server for on-the-fly type stripping and instant browser updates.
+        <div class="p-4 rounded-xl bg-slate-50 dark:bg-slate-900/80 border-l-4 border-slate-600 dark:border-slate-400 text-sm text-slate-700 dark:text-slate-300">
+          <span class="font-bold text-slate-900 dark:text-slate-100">Note:</span> During development, Vite provides instant HMR and on-the-fly type stripping for seamless browser testing.
         </div>
       </section>
 
-      <!-- Section 2: Components -->
+      <!-- Section 2: Structure -->
+      <section id="structure" class="mb-14 scroll-mt-24">
+        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">2</span>
+          Project Architecture & Structure
+        </h2>
+
+        <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-4">
+          Boba maintains a clean, flat architecture where components, routes, and core utilities are explicitly organized:
+        </p>
+
+        <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs border border-slate-800 shadow-sm overflow-x-auto mb-6">
+<pre class="text-slate-300">
+my-app/
+├── index.html              # Main entry HTML file
+├── package.json            # Node.js dependencies & scripts
+├── src/
+│   ├── main.ts             # Application bootstrapper & route definitions
+│   ├── core/               # Core framework abstractions
+│   │   ├── base-component.ts  # Base web component class
+│   │   ├── store.ts           # EventTarget-backed state store
+│   │   └── router/            # Client-side router engine
+│   ├── components/         # Modular Web Components
+│   └── styles/
+│       └── global.css      # Tailwind v4 & design tokens
+└── e2e/                    # Playwright end-to-end tests
+</pre>
+        </div>
+      </section>
+
+      <!-- Section 3: Web Components -->
       <section id="components" class="mb-14 scroll-mt-24">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
-          <span class="w-8 h-8 rounded-lg bg-emerald-100 dark:bg-emerald-950 text-emerald-600 dark:text-emerald-400 flex items-center justify-center text-sm font-extrabold">2</span>
-          Web Components
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">3</span>
+          BaseComponent & Light DOM Styling
         </h2>
 
         <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
-          Components inherit from <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-sky-600 dark:text-sky-400 font-mono text-xs">BaseComponent</code>, providing scoped styles, Light DOM integration for global Tailwind utility compatibility, and lifecycle hooks.
+          Components inherit from <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-mono text-xs">BaseComponent</code>. To allow full integration with Tailwind CSS utility classes, Shadow DOM is disabled in favor of Light DOM rendering with simulated style scoping.
         </p>
 
         <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs sm:text-sm border border-slate-800 shadow-sm overflow-x-auto mb-6">
-<pre class="text-slate-300"><span class="text-sky-400">import</span> { BaseComponent } <span class="text-sky-400">from</span> <span class="text-emerald-300">'../../core/base-component.ts'</span>;
+<pre class="text-slate-300"><span class="text-slate-400">import</span> { BaseComponent } <span class="text-slate-400">from</span> <span class="text-slate-200">'../../core/base-component.ts'</span>;
 
-<span class="text-sky-400">const</span> html = <span class="text-emerald-300">`&lt;h1 class="text-2xl font-bold text-slate-900"&gt;Hello World&lt;/h1&gt;`</span>;
-<span class="text-sky-400">const</span> css = <span class="text-emerald-300">`:host { display: block; }`</span>;
+<span class="text-slate-400">const</span> html = <span class="text-slate-200">`&lt;div class="p-4 bg-slate-100 text-slate-900 rounded-lg"&gt;Hello Boba&lt;/div&gt;`</span>;
+<span class="text-slate-400">const</span> css = <span class="text-slate-200">`:host { display: block; }`</span>;
 
-<span class="text-sky-400">export class</span> HelloComponent <span class="text-sky-400">extends</span> BaseComponent {
-  <span class="text-sky-400">static</span> tagName = <span class="text-emerald-300">'hello-component'</span>;
-  <span class="text-sky-400">constructor</span>() {
-    <span class="text-sky-400">super</span>(html, css);
+<span class="text-slate-400">export class</span> DemoComponent <span class="text-slate-400">extends</span> BaseComponent {
+  <span class="text-slate-400">static</span> tagName = <span class="text-slate-200">'demo-component'</span>;
+  <span class="text-slate-400">constructor</span>() {
+    <span class="text-slate-400">super</span>(html, css);
   }
 }
 
-customElements.define(HelloComponent.tagName, HelloComponent);</pre>
+customElements.define(DemoComponent.tagName, DemoComponent);</pre>
         </div>
       </section>
 
-      <!-- Section 3: Routing -->
+      <!-- Section 4: Routing -->
       <section id="routing" class="mb-14 scroll-mt-24">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
-          <span class="w-8 h-8 rounded-lg bg-purple-100 dark:bg-purple-950 text-purple-600 dark:text-purple-400 flex items-center justify-center text-sm font-extrabold">3</span>
-          Smart Client Routing
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">4</span>
+          Smart Client-Side Routing
         </h2>
 
         <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
-          The built-in Boba Router supports client-side SPA navigation, path parameter extraction (<code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-purple-600 dark:text-purple-400 font-mono text-xs">:param</code>), and automatic subpath support for GitHub Pages deployments.
+          The built-in <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-mono text-xs">Router</code> provides seamless SPA navigation, dynamic route parameters (<code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-mono text-xs">:param</code>), and automatic base path resolution for subpath deployments such as GitHub Pages.
         </p>
 
         <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs sm:text-sm border border-slate-800 shadow-sm overflow-x-auto mb-6">
-<pre class="text-slate-300"><span class="text-sky-400">import</span> { Router } <span class="text-sky-400">from</span> <span class="text-emerald-300">'./core/router/router.ts'</span>;
+<pre class="text-slate-300"><span class="text-slate-400">import</span> { Router } <span class="text-slate-400">from</span> <span class="text-slate-200">'./core/router/router.ts'</span>;
 
-<span class="text-sky-400">const</span> router = Router.getInstance();
-router.registerRoute({ path: <span class="text-emerald-300">'/'</span>, component: <span class="text-emerald-300">'home-page'</span> });
-router.registerRoute({ path: <span class="text-emerald-300">'/user/:id'</span>, component: <span class="text-emerald-300">'user-profile'</span> });</pre>
+<span class="text-slate-400">const</span> router = Router.getInstance();
+router.registerRoute({ path: <span class="text-slate-200">'/'</span>, component: <span class="text-slate-200">'home-page'</span> });
+router.registerRoute({ path: <span class="text-slate-200">'/docs'</span>, component: <span class="text-slate-200">'docs-page'</span> });
+router.registerRoute({ path: <span class="text-slate-200">'/user/:name'</span>, component: <span class="text-slate-200">'user-page'</span> });</pre>
         </div>
       </section>
 
-      <!-- Section 4: State -->
+      <!-- Section 5: State -->
       <section id="state" class="mb-14 scroll-mt-24">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
-          <span class="w-8 h-8 rounded-lg bg-amber-100 dark:bg-amber-950 text-amber-600 dark:text-amber-400 flex items-center justify-center text-sm font-extrabold">4</span>
-          Global State
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">5</span>
+          Reactive State Management
         </h2>
 
         <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
-          Lightweight state management backed by standard browser <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-amber-600 dark:text-amber-400 font-mono text-xs">EventTarget</code> events.
+          State management uses native browser <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-mono text-xs">EventTarget</code> events without standard heavy external state libraries.
         </p>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div class="bg-[var(--boba-surface)] p-5 rounded-xl border border-slate-200 dark:border-slate-800">
-            <h3 class="font-bold text-slate-900 dark:text-slate-100 text-base mb-2">Define Store</h3>
-            <code class="block text-xs font-mono text-sky-600 dark:text-sky-400 bg-slate-100 dark:bg-slate-900/80 p-2 rounded-md mb-3">new Store({ count: 0 })</code>
+            <h3 class="font-bold text-slate-900 dark:text-slate-100 text-base mb-2">Create Store</h3>
+            <code class="block text-xs font-mono text-slate-800 dark:text-slate-200 bg-slate-100 dark:bg-slate-900/80 p-2 rounded-md mb-3">export const appStore = new Store({ count: 0 });</code>
             <p class="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
-              Emits native custom events whenever state properties are updated.
+              Updates state using <code class="font-mono">setState()</code> and emits native change events.
             </p>
           </div>
 
           <div class="bg-[var(--boba-surface)] p-5 rounded-xl border border-slate-200 dark:border-slate-800">
-            <h3 class="font-bold text-slate-900 dark:text-slate-100 text-base mb-2">Subscribe</h3>
-            <code class="block text-xs font-mono text-purple-600 dark:text-purple-400 bg-slate-100 dark:bg-slate-900/80 p-2 rounded-md mb-3">store.addEventListener('change', ...)</code>
+            <h3 class="font-bold text-slate-900 dark:text-slate-100 text-base mb-2">Listen in Components</h3>
+            <code class="block text-xs font-mono text-slate-800 dark:text-slate-200 bg-slate-100 dark:bg-slate-900/80 p-2 rounded-md mb-3">appStore.addEventListener('change', ...)</code>
             <p class="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
-              Components listen to state changes inside their <code class="font-mono">init()</code> lifecycle method.
+              Components subscribe inside <code class="font-mono">init()</code> to automatically update UI on changes.
             </p>
           </div>
+        </div>
+      </section>
+
+      <!-- Section 6: Deployment -->
+      <section id="deployment" class="mb-14 scroll-mt-24">
+        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">6</span>
+          Production Build & Deployment
+        </h2>
+
+        <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
+          To generate static production assets suitable for GitHub Pages, Netlify, or Vercel, run the production build script:
+        </p>
+
+        <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs sm:text-sm border border-slate-800 shadow-sm mb-6 overflow-x-auto">
+          <div class="text-slate-500 mb-2"># Build static dist bundle</div>
+          <div class="text-slate-200 mb-3">npm run build</div>
+          <div class="text-slate-500 mb-2"># Preview static build locally</div>
+          <div class="text-slate-200">npx serve dist</div>
         </div>
       </section>
 
       <!-- Footer -->
       <footer class="pt-8 border-t border-slate-200 dark:border-slate-800 text-xs text-slate-500 dark:text-slate-400 text-center">
-        &copy; <span data-year></span> Boba Framework. Built for modern software engineering.
+        &copy; Boba Framework. Distributed under the MIT License.
       </footer>
 
     </main>

--- a/src/components/home-page/home-page.html
+++ b/src/components/home-page/home-page.html
@@ -3,8 +3,8 @@
 
     <!-- Hero Section (VitePress / O365 Aesthetic) -->
     <header class="text-center pt-8 pb-16 max-w-3xl mx-auto">
-      <div class="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-sky-50 dark:bg-sky-950/60 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800/60 mb-6 shadow-sm">
-        <span class="w-2 h-2 rounded-full bg-sky-500"></span>
+      <div class="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 mb-6 shadow-sm">
+        <span class="w-2 h-2 rounded-full bg-slate-500"></span>
         <span>Zero-Build Web Components & Native TypeScript</span>
       </div>
 
@@ -17,7 +17,7 @@
       </p>
 
       <div class="flex flex-wrap items-center justify-center gap-4">
-        <a href="/docs" class="inline-flex items-center justify-center px-6 py-3 rounded-lg text-sm font-semibold text-white bg-sky-600 hover:bg-sky-700 dark:bg-sky-500 dark:hover:bg-sky-400 shadow-sm transition-all">
+        <a href="/docs" class="inline-flex items-center justify-center px-6 py-3 rounded-lg text-sm font-semibold text-white bg-slate-900 hover:bg-slate-800 dark:bg-slate-100 dark:hover:bg-slate-200 dark:text-slate-900 shadow-sm transition-all">
           Get Started
           <svg class="w-4 h-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
@@ -33,12 +33,12 @@
       </div>
     </header>
 
-    <!-- Core Features Grid (O365 / VitePress Style) -->
+    <!-- Core Features Grid -->
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
 
       <!-- Card 1 -->
-      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-sky-500/50 dark:hover:border-sky-500/50 transition-all shadow-sm">
-        <div class="w-10 h-10 rounded-lg bg-sky-100 dark:bg-sky-950 text-sky-600 dark:text-sky-400 flex items-center justify-center mb-4">
+      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all shadow-sm">
+        <div class="w-10 h-10 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center mb-4">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
           </svg>
@@ -50,8 +50,8 @@
       </div>
 
       <!-- Card 2 -->
-      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-emerald-500/50 dark:hover:border-emerald-500/50 transition-all shadow-sm">
-        <div class="w-10 h-10 rounded-lg bg-emerald-100 dark:bg-emerald-950 text-emerald-600 dark:text-emerald-400 flex items-center justify-center mb-4">
+      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all shadow-sm">
+        <div class="w-10 h-10 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center mb-4">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
           </svg>
@@ -63,8 +63,8 @@
       </div>
 
       <!-- Card 3 -->
-      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-purple-500/50 dark:hover:border-purple-500/50 transition-all shadow-sm">
-        <div class="w-10 h-10 rounded-lg bg-purple-100 dark:bg-purple-950 text-purple-600 dark:text-purple-400 flex items-center justify-center mb-4">
+      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all shadow-sm">
+        <div class="w-10 h-10 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center mb-4">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
           </svg>
@@ -82,15 +82,15 @@
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between pb-6 border-b border-slate-200 dark:border-slate-800 mb-6 gap-4">
         <div>
           <h2 class="text-xl font-bold text-slate-900 dark:text-slate-100 flex items-center gap-2">
-            <svg class="w-5 h-5 text-sky-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <svg class="w-5 h-5 text-slate-700 dark:text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             System Status & CI Metrics
           </h2>
           <p class="text-xs text-slate-500 dark:text-slate-400 mt-1">Real-time status monitoring from GitHub Actions workflow runs.</p>
         </div>
-        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-emerald-100 dark:bg-emerald-950/80 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-800">
-          <span class="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
+        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700">
+          <span class="w-2 h-2 rounded-full bg-slate-500"></span>
           All Systems Operational
         </span>
       </div>
@@ -100,7 +100,7 @@
         <div class="bg-slate-50 dark:bg-slate-900/60 p-4 rounded-lg border border-slate-200 dark:border-slate-800/80">
           <div class="text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Unit Test Suite</div>
           <div class="flex items-center gap-2">
-            <span class="text-base font-bold text-emerald-600 dark:text-emerald-400">PASSING</span>
+            <span class="text-base font-bold text-slate-800 dark:text-slate-200">PASSING</span>
             <span class="text-xs font-mono text-slate-400 dark:text-slate-500">(node --test)</span>
           </div>
         </div>
@@ -108,7 +108,7 @@
         <div class="bg-slate-50 dark:bg-slate-900/60 p-4 rounded-lg border border-slate-200 dark:border-slate-800/80">
           <div class="text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Playwright E2E Suite</div>
           <div class="flex items-center gap-2">
-            <span class="text-base font-bold text-emerald-600 dark:text-emerald-400">PASSING</span>
+            <span class="text-base font-bold text-slate-800 dark:text-slate-200">PASSING</span>
             <span class="text-xs font-mono text-slate-400 dark:text-slate-500">(10/10 specs)</span>
           </div>
         </div>
@@ -116,7 +116,7 @@
         <div class="bg-slate-50 dark:bg-slate-900/60 p-4 rounded-lg border border-slate-200 dark:border-slate-800/80">
           <div class="text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Current Version Tag</div>
           <div class="flex items-center gap-2">
-            <span id="version-tag" class="text-base font-bold text-sky-600 dark:text-sky-400 font-mono">v1.0.0</span>
+            <span id="version-tag" class="text-base font-bold text-slate-800 dark:text-slate-200 font-mono">v1.0.0</span>
             <span class="text-xs font-mono text-slate-400 dark:text-slate-500">(Stable Release)</span>
           </div>
         </div>

--- a/src/components/home-page/home-page.ts
+++ b/src/components/home-page/home-page.ts
@@ -1,4 +1,5 @@
 import { BaseComponent } from '../../core/base-component.ts';
+import { Router } from '../../core/router/router.ts';
 import template from './home-page.html?raw';
 import style from './home-page.css?raw';
 
@@ -12,6 +13,16 @@ export class HomeComponent extends BaseComponent {
   init() {
     this.querySelector('#version-tag')?.addEventListener('click', () => {
       console.log('Boba Framework v1.0.0 initialized');
+    });
+
+    this.querySelectorAll('a').forEach((link) => {
+      const href = link.getAttribute('href');
+      if (href && href.startsWith('/')) {
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          Router.getInstance().navigate(href);
+        });
+      }
     });
   }
 }

--- a/src/components/nav-page/nav-page.html
+++ b/src/components/nav-page/nav-page.html
@@ -4,21 +4,20 @@
     <!-- Left Section: Logo & Primary Nav -->
     <div class="flex items-center space-x-8">
       <a href="/" class="flex items-center space-x-2.5 group">
-        <div class="w-8 h-8 rounded-lg bg-sky-600 dark:bg-sky-500 text-white flex items-center justify-center font-bold shadow-sm shadow-sky-500/30 group-hover:bg-sky-700 dark:group-hover:bg-sky-400 transition-colors">
+        <div class="w-8 h-8 rounded-lg bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 flex items-center justify-center font-bold shadow-sm transition-colors">
           <svg class="w-5 h-5 fill-current" viewBox="0 0 24 24">
             <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm1 14.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zm-1-3.5a1.5 1.5 0 01-1.5-1.5V8a1.5 1.5 0 013 0v3.5A1.5 1.5 0 0112 13z"/>
           </svg>
         </div>
         <div class="flex items-center gap-2">
           <span class="text-lg font-bold tracking-tight text-slate-900 dark:text-slate-50 font-sans">Boba</span>
-          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-sky-100 dark:bg-sky-950/80 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800/60">
+          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700">
             v1.0.0
           </span>
         </div>
       </a>
 
       <nav class="hidden md:flex items-center space-x-1 text-sm font-medium">
-        <a href="/" class="px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors">Home</a>
         <a href="/docs" class="px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors">Docs</a>
         <a href="/about" class="px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors">About</a>
         <a href="/todo" class="px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors">To-Do</a>
@@ -29,16 +28,16 @@
     <div class="flex items-center space-x-3 sm:space-x-4">
 
       <!-- Build & Test Status Badge -->
-      <a href="https://github.com/sholtomaud/boba/actions" target="_blank" rel="noopener noreferrer" class="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800/50 hover:bg-emerald-100 dark:hover:bg-emerald-900/60 transition-colors" title="GitHub Actions Workflow Status">
+      <a href="https://github.com/sholtomaud/boba/actions" target="_blank" rel="noopener noreferrer" class="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold bg-slate-100 dark:bg-slate-800/80 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors" title="GitHub Actions Workflow Status">
         <span class="relative flex h-2 w-2">
-          <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-          <span class="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"></span>
+          <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-slate-400 opacity-75"></span>
+          <span class="relative inline-flex rounded-full h-2 w-2 bg-slate-500"></span>
         </span>
         <span class="font-mono text-[11px]">CI / Build: Passing</span>
       </a>
 
       <!-- GitHub Link -->
-      <a href="https://github.com/sholtomaud/boba" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold bg-slate-900 hover:bg-slate-800 text-white dark:bg-slate-800 dark:hover:bg-slate-700 dark:text-slate-100 border border-slate-700 dark:border-slate-600 transition-colors shadow-sm" title="View Source Code on GitHub">
+      <a href="https://github.com/sholtomaud/boba" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold bg-slate-900 hover:bg-slate-800 text-white dark:bg-slate-100 dark:hover:bg-slate-200 dark:text-slate-900 border border-slate-800 dark:border-slate-200 transition-colors shadow-sm" title="View Source Code on GitHub">
         <svg class="w-4 h-4 fill-current" viewBox="0 0 24 24" aria-hidden="true">
           <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"></path>
         </svg>
@@ -50,9 +49,8 @@
 
   <!-- Mobile Navigation Bar Links -->
   <div class="md:hidden border-t border-slate-200 dark:border-slate-800 px-4 py-2 flex items-center justify-around text-xs font-medium bg-slate-50/50 dark:bg-slate-900/50">
-    <a href="/" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-sky-600 dark:hover:text-sky-400">Home</a>
-    <a href="/docs" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-sky-600 dark:hover:text-sky-400">Docs</a>
-    <a href="/about" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-sky-600 dark:hover:text-sky-400">About</a>
-    <a href="/todo" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-sky-600 dark:hover:text-sky-400">To-Do</a>
+    <a href="/docs" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100">Docs</a>
+    <a href="/about" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100">About</a>
+    <a href="/todo" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100">To-Do</a>
   </div>
 </header>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,33 +1,33 @@
 @import "tailwindcss";
 
 :root {
-  /* Boba O365 / VitePress Design System Tokens */
+  /* Boba Minimal / Professional Design System Tokens */
   --boba-primary: #0f172a;
   --boba-secondary: #475569;
-  --boba-accent: #0284c7;
-  --boba-accent-hover: #0369a1;
+  --boba-accent: #334155;
+  --boba-accent-hover: #1e293b;
   --boba-bg: #ffffff;
   --boba-surface: #f8fafc;
   --boba-border: #e2e8f0;
   --boba-text: #0f172a;
   --boba-text-muted: #64748b;
   --boba-code-bg: #0f172a;
-  --boba-nav-bg: rgba(255, 255, 255, 0.85);
+  --boba-nav-bg: rgba(255, 255, 255, 0.9);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --boba-primary: #f8fafc;
     --boba-secondary: #94a3b8;
-    --boba-accent: #38bdf8;
-    --boba-accent-hover: #7dd3fc;
-    --boba-bg: #090d16;
+    --boba-accent: #475569;
+    --boba-accent-hover: #64748b;
+    --boba-bg: #0b0f17;
     --boba-surface: #111827;
     --boba-border: #1e293b;
     --boba-text: #f1f5f9;
     --boba-text-muted: #94a3b8;
     --boba-code-bg: #0f172a;
-    --boba-nav-bg: rgba(9, 13, 22, 0.85);
+    --boba-nav-bg: rgba(11, 15, 23, 0.9);
   }
 }
 

--- a/template/src/components/docs-page/docs-page.html
+++ b/template/src/components/docs-page/docs-page.html
@@ -9,33 +9,41 @@
             Documentation Overview
           </h3>
           <nav class="space-y-1 text-sm font-medium">
-            <a href="#intro" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-              <span class="w-1.5 h-1.5 rounded-full bg-sky-500"></span>
+            <a href="#intro" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
               Getting Started
             </a>
-            <a href="#components" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-              <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-              Web Components
+            <a href="#structure" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
+              Project Structure
             </a>
-            <a href="#routing" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-              <span class="w-1.5 h-1.5 rounded-full bg-purple-500"></span>
-              Smart Routing
+            <a href="#components" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
+              BaseComponent & Light DOM
             </a>
-            <a href="#state" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-              <span class="w-1.5 h-1.5 rounded-full bg-amber-500"></span>
+            <a href="#routing" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
+              Smart Client Routing
+            </a>
+            <a href="#state" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
               State Management
+            </a>
+            <a href="#deployment" class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/60 hover:text-slate-900 dark:hover:text-white transition-colors">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
+              Build & Production Deployment
             </a>
           </nav>
         </div>
 
-        <div class="p-4 rounded-xl bg-sky-50 dark:bg-sky-950/40 border border-sky-200 dark:border-sky-800/60 text-xs text-sky-800 dark:text-sky-200">
-          <div class="font-bold mb-1 flex items-center gap-1.5">
-            <svg class="w-4 h-4 text-sky-600 dark:text-sky-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <div class="p-4 rounded-xl bg-slate-100 dark:bg-slate-900/60 border border-slate-200 dark:border-slate-800 text-xs text-slate-800 dark:text-slate-300">
+          <div class="font-bold mb-1 flex items-center gap-1.5 text-slate-900 dark:text-slate-100">
+            <svg class="w-4 h-4 text-slate-600 dark:text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            Pro Tip
+            Zero-Build Workflow
           </div>
-          Boba runs natively on Node 25+ without any build step required for local dev.
+          Boba runs natively on Node 25+ using native TypeScript type stripping without transpilation overhead.
         </div>
       </div>
     </aside>
@@ -49,118 +57,166 @@
           Documentation
         </h1>
         <p class="text-lg text-slate-600 dark:text-slate-300 leading-relaxed font-normal">
-          Everything you need to know about building enterprise-grade, minimalist web applications with Boba.
+          Comprehensive guide to building minimal, modern, enterprise-grade web applications using Boba.
         </p>
       </header>
 
-      <!-- Section 1: Intro -->
+      <!-- Section 1: Quickstart -->
       <section id="intro" class="mb-14 scroll-mt-24">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
-          <span class="w-8 h-8 rounded-lg bg-sky-100 dark:bg-sky-950 text-sky-600 dark:text-sky-400 flex items-center justify-center text-sm font-extrabold">1</span>
-          Getting Started
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">1</span>
+          Getting Started & Scaffolding
         </h2>
 
         <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
-          Boba is a zero-build framework leveraging browser standards (Web Components, Light DOM styling, ES Modules) and Node.js v25+ native type stripping for ultra-fast performance.
+          Boba provides a lightweight scaffolding CLI to generate clean, production-ready applications powered by browser standards, native Web Components, and Vite.
         </p>
 
-        <!-- Command Box -->
         <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs sm:text-sm border border-slate-800 shadow-sm mb-6 overflow-x-auto">
-          <div class="text-slate-500 mb-2"># Scaffold a new Boba application</div>
-          <div class="text-sky-400 mb-3">npx github:sholtomaud/boba my-boba-app</div>
+          <div class="text-slate-500 mb-2"># Scaffold a new Boba project</div>
+          <div class="text-slate-200 mb-3">npx github:sholtomaud/boba my-app</div>
           <div class="text-slate-500 mb-2"># Navigate and install dependencies</div>
-          <div class="text-slate-200 mb-3">cd my-boba-app && npm install</div>
-          <div class="text-slate-500 mb-2"># Launch live dev server</div>
-          <div class="text-emerald-400">npm start</div>
+          <div class="text-slate-200 mb-3">cd my-app && npm install</div>
+          <div class="text-slate-500 mb-2"># Start Vite development server</div>
+          <div class="text-slate-200">npm start</div>
         </div>
 
-        <!-- VitePress-style Callout Note -->
-        <div class="p-4 rounded-xl bg-slate-50 dark:bg-slate-900/80 border-l-4 border-sky-500 text-sm text-slate-700 dark:text-slate-300">
-          <span class="font-bold text-slate-900 dark:text-slate-100">Note:</span> Running <code class="px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-800 font-mono text-xs">npm start</code> starts Vite dev server for on-the-fly type stripping and instant browser updates.
+        <div class="p-4 rounded-xl bg-slate-50 dark:bg-slate-900/80 border-l-4 border-slate-600 dark:border-slate-400 text-sm text-slate-700 dark:text-slate-300">
+          <span class="font-bold text-slate-900 dark:text-slate-100">Note:</span> During development, Vite provides instant HMR and on-the-fly type stripping for seamless browser testing.
         </div>
       </section>
 
-      <!-- Section 2: Components -->
+      <!-- Section 2: Structure -->
+      <section id="structure" class="mb-14 scroll-mt-24">
+        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">2</span>
+          Project Architecture & Structure
+        </h2>
+
+        <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-4">
+          Boba maintains a clean, flat architecture where components, routes, and core utilities are explicitly organized:
+        </p>
+
+        <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs border border-slate-800 shadow-sm overflow-x-auto mb-6">
+<pre class="text-slate-300">
+my-app/
+├── index.html              # Main entry HTML file
+├── package.json            # Node.js dependencies & scripts
+├── src/
+│   ├── main.ts             # Application bootstrapper & route definitions
+│   ├── core/               # Core framework abstractions
+│   │   ├── base-component.ts  # Base web component class
+│   │   ├── store.ts           # EventTarget-backed state store
+│   │   └── router/            # Client-side router engine
+│   ├── components/         # Modular Web Components
+│   └── styles/
+│       └── global.css      # Tailwind v4 & design tokens
+└── e2e/                    # Playwright end-to-end tests
+</pre>
+        </div>
+      </section>
+
+      <!-- Section 3: Web Components -->
       <section id="components" class="mb-14 scroll-mt-24">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
-          <span class="w-8 h-8 rounded-lg bg-emerald-100 dark:bg-emerald-950 text-emerald-600 dark:text-emerald-400 flex items-center justify-center text-sm font-extrabold">2</span>
-          Web Components
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">3</span>
+          BaseComponent & Light DOM Styling
         </h2>
 
         <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
-          Components inherit from <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-sky-600 dark:text-sky-400 font-mono text-xs">BaseComponent</code>, providing scoped styles, Light DOM integration for global Tailwind utility compatibility, and lifecycle hooks.
+          Components inherit from <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-mono text-xs">BaseComponent</code>. To allow full integration with Tailwind CSS utility classes, Shadow DOM is disabled in favor of Light DOM rendering with simulated style scoping.
         </p>
 
         <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs sm:text-sm border border-slate-800 shadow-sm overflow-x-auto mb-6">
-<pre class="text-slate-300"><span class="text-sky-400">import</span> { BaseComponent } <span class="text-sky-400">from</span> <span class="text-emerald-300">'../../core/base-component.ts'</span>;
+<pre class="text-slate-300"><span class="text-slate-400">import</span> { BaseComponent } <span class="text-slate-400">from</span> <span class="text-slate-200">'../../core/base-component.ts'</span>;
 
-<span class="text-sky-400">const</span> html = <span class="text-emerald-300">`&lt;h1 class="text-2xl font-bold text-slate-900"&gt;Hello World&lt;/h1&gt;`</span>;
-<span class="text-sky-400">const</span> css = <span class="text-emerald-300">`:host { display: block; }`</span>;
+<span class="text-slate-400">const</span> html = <span class="text-slate-200">`&lt;div class="p-4 bg-slate-100 text-slate-900 rounded-lg"&gt;Hello Boba&lt;/div&gt;`</span>;
+<span class="text-slate-400">const</span> css = <span class="text-slate-200">`:host { display: block; }`</span>;
 
-<span class="text-sky-400">export class</span> HelloComponent <span class="text-sky-400">extends</span> BaseComponent {
-  <span class="text-sky-400">static</span> tagName = <span class="text-emerald-300">'hello-component'</span>;
-  <span class="text-sky-400">constructor</span>() {
-    <span class="text-sky-400">super</span>(html, css);
+<span class="text-slate-400">export class</span> DemoComponent <span class="text-slate-400">extends</span> BaseComponent {
+  <span class="text-slate-400">static</span> tagName = <span class="text-slate-200">'demo-component'</span>;
+  <span class="text-slate-400">constructor</span>() {
+    <span class="text-slate-400">super</span>(html, css);
   }
 }
 
-customElements.define(HelloComponent.tagName, HelloComponent);</pre>
+customElements.define(DemoComponent.tagName, DemoComponent);</pre>
         </div>
       </section>
 
-      <!-- Section 3: Routing -->
+      <!-- Section 4: Routing -->
       <section id="routing" class="mb-14 scroll-mt-24">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
-          <span class="w-8 h-8 rounded-lg bg-purple-100 dark:bg-purple-950 text-purple-600 dark:text-purple-400 flex items-center justify-center text-sm font-extrabold">3</span>
-          Smart Client Routing
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">4</span>
+          Smart Client-Side Routing
         </h2>
 
         <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
-          The built-in Boba Router supports client-side SPA navigation, path parameter extraction (<code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-purple-600 dark:text-purple-400 font-mono text-xs">:param</code>), and automatic subpath support for GitHub Pages deployments.
+          The built-in <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-mono text-xs">Router</code> provides seamless SPA navigation, dynamic route parameters (<code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-mono text-xs">:param</code>), and automatic base path resolution for subpath deployments such as GitHub Pages.
         </p>
 
         <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs sm:text-sm border border-slate-800 shadow-sm overflow-x-auto mb-6">
-<pre class="text-slate-300"><span class="text-sky-400">import</span> { Router } <span class="text-sky-400">from</span> <span class="text-emerald-300">'./core/router/router.ts'</span>;
+<pre class="text-slate-300"><span class="text-slate-400">import</span> { Router } <span class="text-slate-400">from</span> <span class="text-slate-200">'./core/router/router.ts'</span>;
 
-<span class="text-sky-400">const</span> router = Router.getInstance();
-router.registerRoute({ path: <span class="text-emerald-300">'/'</span>, component: <span class="text-emerald-300">'home-page'</span> });
-router.registerRoute({ path: <span class="text-emerald-300">'/user/:id'</span>, component: <span class="text-emerald-300">'user-profile'</span> });</pre>
+<span class="text-slate-400">const</span> router = Router.getInstance();
+router.registerRoute({ path: <span class="text-slate-200">'/'</span>, component: <span class="text-slate-200">'home-page'</span> });
+router.registerRoute({ path: <span class="text-slate-200">'/docs'</span>, component: <span class="text-slate-200">'docs-page'</span> });
+router.registerRoute({ path: <span class="text-slate-200">'/user/:name'</span>, component: <span class="text-slate-200">'user-page'</span> });</pre>
         </div>
       </section>
 
-      <!-- Section 4: State -->
+      <!-- Section 5: State -->
       <section id="state" class="mb-14 scroll-mt-24">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
-          <span class="w-8 h-8 rounded-lg bg-amber-100 dark:bg-amber-950 text-amber-600 dark:text-amber-400 flex items-center justify-center text-sm font-extrabold">4</span>
-          Global State
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">5</span>
+          Reactive State Management
         </h2>
 
         <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
-          Lightweight state management backed by standard browser <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-amber-600 dark:text-amber-400 font-mono text-xs">EventTarget</code> events.
+          State management uses native browser <code class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-mono text-xs">EventTarget</code> events without standard heavy external state libraries.
         </p>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div class="bg-[var(--boba-surface)] p-5 rounded-xl border border-slate-200 dark:border-slate-800">
-            <h3 class="font-bold text-slate-900 dark:text-slate-100 text-base mb-2">Define Store</h3>
-            <code class="block text-xs font-mono text-sky-600 dark:text-sky-400 bg-slate-100 dark:bg-slate-900/80 p-2 rounded-md mb-3">new Store({ count: 0 })</code>
+            <h3 class="font-bold text-slate-900 dark:text-slate-100 text-base mb-2">Create Store</h3>
+            <code class="block text-xs font-mono text-slate-800 dark:text-slate-200 bg-slate-100 dark:bg-slate-900/80 p-2 rounded-md mb-3">export const appStore = new Store({ count: 0 });</code>
             <p class="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
-              Emits native custom events whenever state properties are updated.
+              Updates state using <code class="font-mono">setState()</code> and emits native change events.
             </p>
           </div>
 
           <div class="bg-[var(--boba-surface)] p-5 rounded-xl border border-slate-200 dark:border-slate-800">
-            <h3 class="font-bold text-slate-900 dark:text-slate-100 text-base mb-2">Subscribe</h3>
-            <code class="block text-xs font-mono text-purple-600 dark:text-purple-400 bg-slate-100 dark:bg-slate-900/80 p-2 rounded-md mb-3">store.addEventListener('change', ...)</code>
+            <h3 class="font-bold text-slate-900 dark:text-slate-100 text-base mb-2">Listen in Components</h3>
+            <code class="block text-xs font-mono text-slate-800 dark:text-slate-200 bg-slate-100 dark:bg-slate-900/80 p-2 rounded-md mb-3">appStore.addEventListener('change', ...)</code>
             <p class="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
-              Components listen to state changes inside their <code class="font-mono">init()</code> lifecycle method.
+              Components subscribe inside <code class="font-mono">init()</code> to automatically update UI on changes.
             </p>
           </div>
+        </div>
+      </section>
+
+      <!-- Section 6: Deployment -->
+      <section id="deployment" class="mb-14 scroll-mt-24">
+        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-3">
+          <span class="w-8 h-8 rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center text-sm font-extrabold">6</span>
+          Production Build & Deployment
+        </h2>
+
+        <p class="text-slate-600 dark:text-slate-300 text-sm sm:text-base leading-relaxed mb-6">
+          To generate static production assets suitable for GitHub Pages, Netlify, or Vercel, run the production build script:
+        </p>
+
+        <div class="rounded-xl bg-slate-900 text-slate-100 p-5 font-mono text-xs sm:text-sm border border-slate-800 shadow-sm mb-6 overflow-x-auto">
+          <div class="text-slate-500 mb-2"># Build static dist bundle</div>
+          <div class="text-slate-200 mb-3">npm run build</div>
+          <div class="text-slate-500 mb-2"># Preview static build locally</div>
+          <div class="text-slate-200">npx serve dist</div>
         </div>
       </section>
 
       <!-- Footer -->
       <footer class="pt-8 border-t border-slate-200 dark:border-slate-800 text-xs text-slate-500 dark:text-slate-400 text-center">
-        &copy; <span data-year></span> Boba Framework. Built for modern software engineering.
+        &copy; Boba Framework. Distributed under the MIT License.
       </footer>
 
     </main>

--- a/template/src/components/home-page/home-page.html
+++ b/template/src/components/home-page/home-page.html
@@ -3,8 +3,8 @@
 
     <!-- Hero Section (VitePress / O365 Aesthetic) -->
     <header class="text-center pt-8 pb-16 max-w-3xl mx-auto">
-      <div class="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-sky-50 dark:bg-sky-950/60 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800/60 mb-6 shadow-sm">
-        <span class="w-2 h-2 rounded-full bg-sky-500"></span>
+      <div class="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 mb-6 shadow-sm">
+        <span class="w-2 h-2 rounded-full bg-slate-500"></span>
         <span>Zero-Build Web Components & Native TypeScript</span>
       </div>
 
@@ -17,7 +17,7 @@
       </p>
 
       <div class="flex flex-wrap items-center justify-center gap-4">
-        <a href="/docs" class="inline-flex items-center justify-center px-6 py-3 rounded-lg text-sm font-semibold text-white bg-sky-600 hover:bg-sky-700 dark:bg-sky-500 dark:hover:bg-sky-400 shadow-sm transition-all">
+        <a href="/docs" class="inline-flex items-center justify-center px-6 py-3 rounded-lg text-sm font-semibold text-white bg-slate-900 hover:bg-slate-800 dark:bg-slate-100 dark:hover:bg-slate-200 dark:text-slate-900 shadow-sm transition-all">
           Get Started
           <svg class="w-4 h-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
@@ -33,12 +33,12 @@
       </div>
     </header>
 
-    <!-- Core Features Grid (O365 / VitePress Style) -->
+    <!-- Core Features Grid -->
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
 
       <!-- Card 1 -->
-      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-sky-500/50 dark:hover:border-sky-500/50 transition-all shadow-sm">
-        <div class="w-10 h-10 rounded-lg bg-sky-100 dark:bg-sky-950 text-sky-600 dark:text-sky-400 flex items-center justify-center mb-4">
+      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all shadow-sm">
+        <div class="w-10 h-10 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center mb-4">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
           </svg>
@@ -50,8 +50,8 @@
       </div>
 
       <!-- Card 2 -->
-      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-emerald-500/50 dark:hover:border-emerald-500/50 transition-all shadow-sm">
-        <div class="w-10 h-10 rounded-lg bg-emerald-100 dark:bg-emerald-950 text-emerald-600 dark:text-emerald-400 flex items-center justify-center mb-4">
+      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all shadow-sm">
+        <div class="w-10 h-10 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center mb-4">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
           </svg>
@@ -63,8 +63,8 @@
       </div>
 
       <!-- Card 3 -->
-      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-purple-500/50 dark:hover:border-purple-500/50 transition-all shadow-sm">
-        <div class="w-10 h-10 rounded-lg bg-purple-100 dark:bg-purple-950 text-purple-600 dark:text-purple-400 flex items-center justify-center mb-4">
+      <div class="bg-[var(--boba-surface)] p-6 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all shadow-sm">
+        <div class="w-10 h-10 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex items-center justify-center mb-4">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
           </svg>
@@ -82,15 +82,15 @@
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between pb-6 border-b border-slate-200 dark:border-slate-800 mb-6 gap-4">
         <div>
           <h2 class="text-xl font-bold text-slate-900 dark:text-slate-100 flex items-center gap-2">
-            <svg class="w-5 h-5 text-sky-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <svg class="w-5 h-5 text-slate-700 dark:text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             System Status & CI Metrics
           </h2>
           <p class="text-xs text-slate-500 dark:text-slate-400 mt-1">Real-time status monitoring from GitHub Actions workflow runs.</p>
         </div>
-        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-emerald-100 dark:bg-emerald-950/80 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-800">
-          <span class="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
+        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700">
+          <span class="w-2 h-2 rounded-full bg-slate-500"></span>
           All Systems Operational
         </span>
       </div>
@@ -100,7 +100,7 @@
         <div class="bg-slate-50 dark:bg-slate-900/60 p-4 rounded-lg border border-slate-200 dark:border-slate-800/80">
           <div class="text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Unit Test Suite</div>
           <div class="flex items-center gap-2">
-            <span class="text-base font-bold text-emerald-600 dark:text-emerald-400">PASSING</span>
+            <span class="text-base font-bold text-slate-800 dark:text-slate-200">PASSING</span>
             <span class="text-xs font-mono text-slate-400 dark:text-slate-500">(node --test)</span>
           </div>
         </div>
@@ -108,7 +108,7 @@
         <div class="bg-slate-50 dark:bg-slate-900/60 p-4 rounded-lg border border-slate-200 dark:border-slate-800/80">
           <div class="text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Playwright E2E Suite</div>
           <div class="flex items-center gap-2">
-            <span class="text-base font-bold text-emerald-600 dark:text-emerald-400">PASSING</span>
+            <span class="text-base font-bold text-slate-800 dark:text-slate-200">PASSING</span>
             <span class="text-xs font-mono text-slate-400 dark:text-slate-500">(10/10 specs)</span>
           </div>
         </div>
@@ -116,7 +116,7 @@
         <div class="bg-slate-50 dark:bg-slate-900/60 p-4 rounded-lg border border-slate-200 dark:border-slate-800/80">
           <div class="text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Current Version Tag</div>
           <div class="flex items-center gap-2">
-            <span id="version-tag" class="text-base font-bold text-sky-600 dark:text-sky-400 font-mono">v1.0.0</span>
+            <span id="version-tag" class="text-base font-bold text-slate-800 dark:text-slate-200 font-mono">v1.0.0</span>
             <span class="text-xs font-mono text-slate-400 dark:text-slate-500">(Stable Release)</span>
           </div>
         </div>

--- a/template/src/components/home-page/home-page.ts
+++ b/template/src/components/home-page/home-page.ts
@@ -1,4 +1,5 @@
 import { BaseComponent } from '../../core/base-component.ts';
+import { Router } from '../../core/router/router.ts';
 import { appStore } from '../../store/app-store.ts';
 import template from './home-page.html?raw';
 import style from './home-page.css?raw';
@@ -17,6 +18,16 @@ export class HomeComponent extends BaseComponent {
     appStore.addEventListener('change', ((e: CustomEvent) => {
       this.updateCounter(e.detail.count);
     }) as EventListener);
+
+    this.querySelectorAll('a').forEach((link) => {
+      const href = link.getAttribute('href');
+      if (href && href.startsWith('/')) {
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          Router.getInstance().navigate(href);
+        });
+      }
+    });
   }
 
   setupEventListeners() {

--- a/template/src/components/nav-page/nav-page.html
+++ b/template/src/components/nav-page/nav-page.html
@@ -4,21 +4,20 @@
     <!-- Left Section: Logo & Primary Nav -->
     <div class="flex items-center space-x-8">
       <a href="/" class="flex items-center space-x-2.5 group">
-        <div class="w-8 h-8 rounded-lg bg-sky-600 dark:bg-sky-500 text-white flex items-center justify-center font-bold shadow-sm shadow-sky-500/30 group-hover:bg-sky-700 dark:group-hover:bg-sky-400 transition-colors">
+        <div class="w-8 h-8 rounded-lg bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 flex items-center justify-center font-bold shadow-sm transition-colors">
           <svg class="w-5 h-5 fill-current" viewBox="0 0 24 24">
             <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm1 14.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zm-1-3.5a1.5 1.5 0 01-1.5-1.5V8a1.5 1.5 0 013 0v3.5A1.5 1.5 0 0112 13z"/>
           </svg>
         </div>
         <div class="flex items-center gap-2">
           <span class="text-lg font-bold tracking-tight text-slate-900 dark:text-slate-50 font-sans">Boba</span>
-          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-sky-100 dark:bg-sky-950/80 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800/60">
+          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700">
             v1.0.0
           </span>
         </div>
       </a>
 
       <nav class="hidden md:flex items-center space-x-1 text-sm font-medium">
-        <a href="/" class="px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors">Home</a>
         <a href="/docs" class="px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors">Docs</a>
         <a href="/about" class="px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors">About</a>
         <a href="/todo" class="px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors">To-Do</a>
@@ -29,16 +28,16 @@
     <div class="flex items-center space-x-3 sm:space-x-4">
 
       <!-- Build & Test Status Badge -->
-      <a href="https://github.com/sholtomaud/boba/actions" target="_blank" rel="noopener noreferrer" class="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800/50 hover:bg-emerald-100 dark:hover:bg-emerald-900/60 transition-colors" title="GitHub Actions Workflow Status">
+      <a href="https://github.com/sholtomaud/boba/actions" target="_blank" rel="noopener noreferrer" class="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold bg-slate-100 dark:bg-slate-800/80 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors" title="GitHub Actions Workflow Status">
         <span class="relative flex h-2 w-2">
-          <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-          <span class="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"></span>
+          <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-slate-400 opacity-75"></span>
+          <span class="relative inline-flex rounded-full h-2 w-2 bg-slate-500"></span>
         </span>
         <span class="font-mono text-[11px]">CI / Build: Passing</span>
       </a>
 
       <!-- GitHub Link -->
-      <a href="https://github.com/sholtomaud/boba" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold bg-slate-900 hover:bg-slate-800 text-white dark:bg-slate-800 dark:hover:bg-slate-700 dark:text-slate-100 border border-slate-700 dark:border-slate-600 transition-colors shadow-sm" title="View Source Code on GitHub">
+      <a href="https://github.com/sholtomaud/boba" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold bg-slate-900 hover:bg-slate-800 text-white dark:bg-slate-100 dark:hover:bg-slate-200 dark:text-slate-900 border border-slate-800 dark:border-slate-200 transition-colors shadow-sm" title="View Source Code on GitHub">
         <svg class="w-4 h-4 fill-current" viewBox="0 0 24 24" aria-hidden="true">
           <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"></path>
         </svg>
@@ -50,9 +49,8 @@
 
   <!-- Mobile Navigation Bar Links -->
   <div class="md:hidden border-t border-slate-200 dark:border-slate-800 px-4 py-2 flex items-center justify-around text-xs font-medium bg-slate-50/50 dark:bg-slate-900/50">
-    <a href="/" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-sky-600 dark:hover:text-sky-400">Home</a>
-    <a href="/docs" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-sky-600 dark:hover:text-sky-400">Docs</a>
-    <a href="/about" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-sky-600 dark:hover:text-sky-400">About</a>
-    <a href="/todo" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-sky-600 dark:hover:text-sky-400">To-Do</a>
+    <a href="/docs" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100">Docs</a>
+    <a href="/about" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100">About</a>
+    <a href="/todo" class="px-2 py-1 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100">To-Do</a>
   </div>
 </header>

--- a/template/src/styles/global.css
+++ b/template/src/styles/global.css
@@ -1,33 +1,33 @@
 @import "tailwindcss";
 
 :root {
-  /* Boba O365 / VitePress Design System Tokens */
+  /* Boba Minimal / Professional Design System Tokens */
   --boba-primary: #0f172a;
   --boba-secondary: #475569;
-  --boba-accent: #0284c7;
-  --boba-accent-hover: #0369a1;
+  --boba-accent: #334155;
+  --boba-accent-hover: #1e293b;
   --boba-bg: #ffffff;
   --boba-surface: #f8fafc;
   --boba-border: #e2e8f0;
   --boba-text: #0f172a;
   --boba-text-muted: #64748b;
   --boba-code-bg: #0f172a;
-  --boba-nav-bg: rgba(255, 255, 255, 0.85);
+  --boba-nav-bg: rgba(255, 255, 255, 0.9);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --boba-primary: #f8fafc;
     --boba-secondary: #94a3b8;
-    --boba-accent: #38bdf8;
-    --boba-accent-hover: #7dd3fc;
-    --boba-bg: #090d16;
+    --boba-accent: #475569;
+    --boba-accent-hover: #64748b;
+    --boba-bg: #0b0f17;
     --boba-surface: #111827;
     --boba-border: #1e293b;
     --boba-text: #f1f5f9;
     --boba-text-muted: #94a3b8;
     --boba-code-bg: #0f172a;
-    --boba-nav-bg: rgba(9, 13, 22, 0.85);
+    --boba-nav-bg: rgba(11, 15, 23, 0.9);
   }
 }
 


### PR DESCRIPTION
Removed the explicit 'Home' nav link (relying on the Boba logo/brand icon to navigate home), fixed the 'Get Started' button link to route smoothly via the SPA Router to the Docs page, expanded the Docs page with comprehensive VitePress-style documentation, and updated the design system and component templates with a minimal, muted, and professional color palette.

Fixes #99

---
*PR created automatically by Jules for task [1877332890776225383](https://jules.google.com/task/1877332890776225383) started by @sholtomaud*