### PR TITLE
Add SVG Favicon and Site Brand Icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws:;"
     />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <title>Boba App</title>
     <script type="module" src="src/main.ts"></script>
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <style>
+    .bg { fill: #0f172a; }
+    .fg { fill: #ffffff; stroke: #ffffff; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #f8fafc; }
+      .fg { fill: #0f172a; stroke: #0f172a; }
+    }
+  </style>
+  <rect class="bg" width="32" height="32" rx="8"/>
+  <g class="fg" transform="translate(4, 4)">
+    <path d="M15 2.5L12 8" stroke-width="2" stroke-linecap="round"/>
+    <rect x="4.5" y="8" width="15" height="2.2" rx="1.1"/>
+    <path d="M6 10.2L7.38 19.16C7.57 20.78 8.94 22 10.58 22H13.42C15.06 22 16.43 20.78 16.62 19.16L18 10.2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <circle cx="9.3" cy="18.3" r="1.3"/>
+    <circle cx="12" cy="18.8" r="1.3"/>
+    <circle cx="14.7" cy="18.3" r="1.3"/>
+    <circle cx="10.6" cy="15.7" r="1.3"/>
+    <circle cx="13.4" cy="15.7" r="1.3"/>
+  </g>
+</svg>

--- a/src/components/nav-page/nav-page.html
+++ b/src/components/nav-page/nav-page.html
@@ -4,9 +4,16 @@
     <!-- Left Section: Logo & Primary Nav -->
     <div class="flex items-center space-x-8">
       <a href="/" class="flex items-center space-x-2.5 group">
-        <div class="w-8 h-8 rounded-lg bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 flex items-center justify-center font-bold shadow-sm transition-colors">
-          <svg class="w-5 h-5 fill-current" viewBox="0 0 24 24">
-            <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm1 14.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zm-1-3.5a1.5 1.5 0 01-1.5-1.5V8a1.5 1.5 0 013 0v3.5A1.5 1.5 0 0112 13z"/>
+        <div class="w-8 h-8 rounded-lg bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 flex items-center justify-center p-1.5 font-bold shadow-sm transition-colors">
+          <svg class="w-full h-full" viewBox="0 0 24 24" fill="none">
+            <path d="M15 2.5L12 8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            <rect x="4.5" y="8" width="15" height="2.2" rx="1.1" fill="currentColor"/>
+            <path d="M6 10.2L7.38 19.16C7.57 20.78 8.94 22 10.58 22H13.42C15.06 22 16.43 20.78 16.62 19.16L18 10.2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <circle cx="9.3" cy="18.3" r="1.3" fill="currentColor"/>
+            <circle cx="12" cy="18.8" r="1.3" fill="currentColor"/>
+            <circle cx="14.7" cy="18.3" r="1.3" fill="currentColor"/>
+            <circle cx="10.6" cy="15.7" r="1.3" fill="currentColor"/>
+            <circle cx="13.4" cy="15.7" r="1.3" fill="currentColor"/>
           </svg>
         </div>
         <div class="flex items-center gap-2">

--- a/template/index.html
+++ b/template/index.html
@@ -7,6 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws:;"
     />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <title>Boba App</title>
     <script type="module" src="src/main.ts"></script>
   </head>

--- a/template/public/favicon.svg
+++ b/template/public/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <style>
+    .bg { fill: #0f172a; }
+    .fg { fill: #ffffff; stroke: #ffffff; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #f8fafc; }
+      .fg { fill: #0f172a; stroke: #0f172a; }
+    }
+  </style>
+  <rect class="bg" width="32" height="32" rx="8"/>
+  <g class="fg" transform="translate(4, 4)">
+    <path d="M15 2.5L12 8" stroke-width="2" stroke-linecap="round"/>
+    <rect x="4.5" y="8" width="15" height="2.2" rx="1.1"/>
+    <path d="M6 10.2L7.38 19.16C7.57 20.78 8.94 22 10.58 22H13.42C15.06 22 16.43 20.78 16.62 19.16L18 10.2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <circle cx="9.3" cy="18.3" r="1.3"/>
+    <circle cx="12" cy="18.8" r="1.3"/>
+    <circle cx="14.7" cy="18.3" r="1.3"/>
+    <circle cx="10.6" cy="15.7" r="1.3"/>
+    <circle cx="13.4" cy="15.7" r="1.3"/>
+  </g>
+</svg>

--- a/template/src/components/nav-page/nav-page.html
+++ b/template/src/components/nav-page/nav-page.html
@@ -4,9 +4,16 @@
     <!-- Left Section: Logo & Primary Nav -->
     <div class="flex items-center space-x-8">
       <a href="/" class="flex items-center space-x-2.5 group">
-        <div class="w-8 h-8 rounded-lg bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 flex items-center justify-center font-bold shadow-sm transition-colors">
-          <svg class="w-5 h-5 fill-current" viewBox="0 0 24 24">
-            <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm1 14.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zm-1-3.5a1.5 1.5 0 01-1.5-1.5V8a1.5 1.5 0 013 0v3.5A1.5 1.5 0 0112 13z"/>
+        <div class="w-8 h-8 rounded-lg bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 flex items-center justify-center p-1.5 font-bold shadow-sm transition-colors">
+          <svg class="w-full h-full" viewBox="0 0 24 24" fill="none">
+            <path d="M15 2.5L12 8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            <rect x="4.5" y="8" width="15" height="2.2" rx="1.1" fill="currentColor"/>
+            <path d="M6 10.2L7.38 19.16C7.57 20.78 8.94 22 10.58 22H13.42C15.06 22 16.43 20.78 16.62 19.16L18 10.2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <circle cx="9.3" cy="18.3" r="1.3" fill="currentColor"/>
+            <circle cx="12" cy="18.8" r="1.3" fill="currentColor"/>
+            <circle cx="14.7" cy="18.3" r="1.3" fill="currentColor"/>
+            <circle cx="10.6" cy="15.7" r="1.3" fill="currentColor"/>
+            <circle cx="13.4" cy="15.7" r="1.3" fill="currentColor"/>
           </svg>
         </div>
         <div class="flex items-center gap-2">


### PR DESCRIPTION
Add a minimal, cool, and standout Boba tea SVG icon as a favicon and site brand logo.

Key changes:
- Created `public/favicon.svg` and `template/public/favicon.svg` with a modern Boba tea design (angled straw, lid, cup body, tapioca pearls) that adapts dynamically to dark/light browser themes.
- Updated `index.html` and `template/index.html` to link the SVG favicon via relative paths.
- Updated `src/components/nav-page/nav-page.html` and `template/src/components/nav-page/nav-page.html` to use the new Boba SVG brand icon in the header.
- Passed CLI unit tests and Playwright E2E tests across root and template projects.

Fixes #101

---
*PR created automatically by Jules for task [605259067793180255](https://jules.google.com/task/605259067793180255) started by @sholtomaud*