### PR TITLE
Align About & To-Do page styles with Home page

### DIFF
--- a/src/components/about-page/about-page.html
+++ b/src/components/about-page/about-page.html
@@ -3,7 +3,7 @@
 
     <!-- Hero Header -->
     <header class="text-center mb-16">
-      <span class="inline-flex items-center px-3.5 py-1 rounded-full text-xs font-semibold bg-sky-50 dark:bg-sky-950/60 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800/60 mb-4 tracking-wide uppercase">
+      <span class="inline-flex items-center px-3.5 py-1 rounded-full text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 mb-4 tracking-wide uppercase shadow-sm">
         About Boba Framework
       </span>
       <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-900 dark:text-slate-50 tracking-tight mb-6">
@@ -18,9 +18,9 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
 
       <!-- Card 1: Standards-First -->
-      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-sky-500/50 transition-all flex flex-col justify-between group shadow-sm">
+      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all flex flex-col justify-between group shadow-sm">
         <div>
-          <div class="w-12 h-12 bg-sky-100 dark:bg-sky-950 text-sky-600 dark:text-sky-400 rounded-lg flex items-center justify-center mb-6">
+          <div class="w-12 h-12 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded-lg flex items-center justify-center mb-6">
             <svg class="w-6 h-6 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-.778.099-1.533.284-2.253" />
             </svg>
@@ -30,15 +30,15 @@
             By utilizing native browser Custom Elements, template interpolation, and standard lifecycle callbacks, Boba has virtually zero runtime overhead. Your codebase remains evergreen and safe from framework deprecation cycles.
           </p>
         </div>
-        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-sky-600 dark:text-sky-400">
+        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-slate-700 dark:text-slate-300">
           Native Web Components Architecture
         </div>
       </div>
 
       <!-- Card 2: Zero Build -->
-      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-indigo-500/50 transition-all flex flex-col justify-between group shadow-sm">
+      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all flex flex-col justify-between group shadow-sm">
         <div>
-          <div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 rounded-lg flex items-center justify-center mb-6">
+          <div class="w-12 h-12 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded-lg flex items-center justify-center mb-6">
             <svg class="w-6 h-6 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
@@ -48,15 +48,15 @@
             Leveraging Node.js v25+ native type stripping means you can run your tests and server logic directly on TypeScript source code. No heavy dev servers and no continuous compilation loops.
           </p>
         </div>
-        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-indigo-600 dark:text-indigo-400">
+        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-slate-700 dark:text-slate-300">
           TypeScript Native Execution
         </div>
       </div>
 
       <!-- Card 3: Secure & Tiny Attack Surface -->
-      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-emerald-500/50 transition-all flex flex-col justify-between group shadow-sm">
+      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all flex flex-col justify-between group shadow-sm">
         <div>
-          <div class="w-12 h-12 bg-emerald-100 dark:bg-emerald-950 text-emerald-600 dark:text-emerald-400 rounded-lg flex items-center justify-center mb-6">
+          <div class="w-12 h-12 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded-lg flex items-center justify-center mb-6">
             <svg class="w-6 h-6 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
             </svg>
@@ -66,15 +66,15 @@
             By avoiding massive node dependency trees (no heavy framework packages or thousands of transient libraries), Boba slashes package installation times and avoids supply chain risks entirely.
           </p>
         </div>
-        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-emerald-600 dark:text-emerald-400">
+        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-slate-700 dark:text-slate-300">
           Zero External Runtime Dependencies
         </div>
       </div>
 
       <!-- Card 4: Reactive Engine -->
-      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-purple-500/50 transition-all flex flex-col justify-between group shadow-sm">
+      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all flex flex-col justify-between group shadow-sm">
         <div>
-          <div class="w-12 h-12 bg-purple-100 dark:bg-purple-950 text-purple-600 dark:text-purple-400 rounded-lg flex items-center justify-center mb-6">
+          <div class="w-12 h-12 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded-lg flex items-center justify-center mb-6">
             <svg class="w-6 h-6 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
             </svg>
@@ -84,7 +84,7 @@
             Built-in EventTarget-based global store and dynamic router bringing route parameters, query parsing, and SPA navigation guards out of the box.
           </p>
         </div>
-        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-purple-600 dark:text-purple-400">
+        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-slate-700 dark:text-slate-300">
           Native Declarative Engine
         </div>
       </div>
@@ -99,8 +99,8 @@
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
 
-        <div class="bg-slate-50 dark:bg-slate-900/60 p-5 rounded-lg border border-sky-300 dark:border-sky-800">
-          <h4 class="text-base font-bold text-sky-700 dark:text-sky-400 mb-3">Boba Framework</h4>
+        <div class="bg-slate-50 dark:bg-slate-900/60 p-5 rounded-lg border border-slate-300 dark:border-slate-700">
+          <h4 class="text-base font-bold text-slate-900 dark:text-slate-100 mb-3">Boba Framework</h4>
           <ul class="text-xs space-y-2.5 text-slate-700 dark:text-slate-300">
             <li class="flex items-center gap-2"><span class="text-emerald-500 font-bold">✔</span> Fast Light DOM</li>
             <li class="flex items-center gap-2"><span class="text-emerald-500 font-bold">✔</span> No Build Pipeline</li>
@@ -135,7 +135,7 @@
     <!-- Developer Best Practices Guidance -->
     <section class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 mb-16">
       <h3 class="text-xl font-bold text-slate-900 dark:text-slate-100 mb-6 flex items-center gap-2">
-        <svg class="w-5 h-5 text-sky-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <svg class="w-5 h-5 text-slate-700 dark:text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
         </svg>
         Styling Best Practices

--- a/src/components/todo-page/todo-page.html
+++ b/src/components/todo-page/todo-page.html
@@ -3,7 +3,7 @@
 
     <!-- Heading -->
     <div class="text-center mb-10">
-      <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-sky-50 dark:bg-sky-950/60 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800/60 mb-3 uppercase tracking-wider">
+      <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 mb-3 uppercase tracking-wider shadow-sm">
         Enterprise Application Demo
       </span>
       <h1 class="text-3xl sm:text-4xl font-extrabold text-slate-900 dark:text-slate-50 tracking-tight mb-2">
@@ -23,12 +23,12 @@
           type="text"
           id="new-task-input"
           placeholder="Add a new task..."
-          class="flex-grow px-4 py-3 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-slate-100 bg-white dark:bg-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 transition-all text-sm font-medium"
+          class="flex-grow px-4 py-3 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-slate-100 bg-white dark:bg-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-all text-sm font-medium"
           autocomplete="off"
         />
         <button
           id="add-task-btn"
-          class="px-5 py-3 bg-sky-600 hover:bg-sky-700 dark:bg-sky-500 dark:hover:bg-sky-400 text-white font-semibold rounded-lg transition-all shadow-sm flex items-center justify-center gap-1.5 text-sm cursor-pointer"
+          class="px-5 py-3 bg-slate-900 hover:bg-slate-800 dark:bg-slate-100 dark:hover:bg-slate-200 text-white dark:text-slate-900 font-semibold rounded-lg transition-all shadow-sm flex items-center justify-center gap-1.5 text-sm cursor-pointer"
         >
           <svg class="w-4 h-4 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -74,7 +74,7 @@
       <!-- Empty State -->
       <div id="empty-state" class="hidden py-10 text-center">
         <svg class="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-3 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.375M9 18h3.375m1.875-10.125A2.25 2.25 0 0115.75 6H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25H6A2.25 2.25 0 016 3.75h1.5m9 0h-9" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.375M9 18h3.375m1.875-10.125A2.25 2.25 0 0115.75 6H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25H6A2.25 2.25 0 013.75 18V6A2.25 2.25 0 016 3.75h1.5m9 0h-9" />
         </svg>
         <p class="text-sm text-slate-400 dark:text-slate-500 font-medium">No tasks found in this view.</p>
       </div>

--- a/template/src/components/about-page/about-page.css
+++ b/template/src/components/about-page/about-page.css
@@ -1,14 +1,3 @@
-.about-container {
-  padding: 2rem;
-  max-width: 800px;
-  margin: 0 auto;
-}
-h1 {
-  color: var(--primary-color, #007bff);
-}
-h2 {
-  margin-top: 1.5rem;
-}
-ul {
-  line-height: 1.6;
+:host {
+  display: block;
 }

--- a/template/src/components/about-page/about-page.html
+++ b/template/src/components/about-page/about-page.html
@@ -3,7 +3,7 @@
 
     <!-- Hero Header -->
     <header class="text-center mb-16">
-      <span class="inline-flex items-center px-3.5 py-1 rounded-full text-xs font-semibold bg-sky-50 dark:bg-sky-950/60 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800/60 mb-4 tracking-wide uppercase">
+      <span class="inline-flex items-center px-3.5 py-1 rounded-full text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 mb-4 tracking-wide uppercase shadow-sm">
         About Boba Framework
       </span>
       <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-900 dark:text-slate-50 tracking-tight mb-6">
@@ -18,9 +18,9 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
 
       <!-- Card 1: Standards-First -->
-      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-sky-500/50 transition-all flex flex-col justify-between group shadow-sm">
+      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all flex flex-col justify-between group shadow-sm">
         <div>
-          <div class="w-12 h-12 bg-sky-100 dark:bg-sky-950 text-sky-600 dark:text-sky-400 rounded-lg flex items-center justify-center mb-6">
+          <div class="w-12 h-12 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded-lg flex items-center justify-center mb-6">
             <svg class="w-6 h-6 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-.778.099-1.533.284-2.253" />
             </svg>
@@ -30,15 +30,15 @@
             By utilizing native browser Custom Elements, template interpolation, and standard lifecycle callbacks, Boba has virtually zero runtime overhead. Your codebase remains evergreen and safe from framework deprecation cycles.
           </p>
         </div>
-        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-sky-600 dark:text-sky-400">
+        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-slate-700 dark:text-slate-300">
           Native Web Components Architecture
         </div>
       </div>
 
       <!-- Card 2: Zero Build -->
-      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-indigo-500/50 transition-all flex flex-col justify-between group shadow-sm">
+      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all flex flex-col justify-between group shadow-sm">
         <div>
-          <div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 rounded-lg flex items-center justify-center mb-6">
+          <div class="w-12 h-12 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded-lg flex items-center justify-center mb-6">
             <svg class="w-6 h-6 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
@@ -48,15 +48,15 @@
             Leveraging Node.js v25+ native type stripping means you can run your tests and server logic directly on TypeScript source code. No heavy dev servers and no continuous compilation loops.
           </p>
         </div>
-        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-indigo-600 dark:text-indigo-400">
+        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-slate-700 dark:text-slate-300">
           TypeScript Native Execution
         </div>
       </div>
 
       <!-- Card 3: Secure & Tiny Attack Surface -->
-      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-emerald-500/50 transition-all flex flex-col justify-between group shadow-sm">
+      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all flex flex-col justify-between group shadow-sm">
         <div>
-          <div class="w-12 h-12 bg-emerald-100 dark:bg-emerald-950 text-emerald-600 dark:text-emerald-400 rounded-lg flex items-center justify-center mb-6">
+          <div class="w-12 h-12 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded-lg flex items-center justify-center mb-6">
             <svg class="w-6 h-6 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
             </svg>
@@ -66,15 +66,15 @@
             By avoiding massive node dependency trees (no heavy framework packages or thousands of transient libraries), Boba slashes package installation times and avoids supply chain risks entirely.
           </p>
         </div>
-        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-emerald-600 dark:text-emerald-400">
+        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-slate-700 dark:text-slate-300">
           Zero External Runtime Dependencies
         </div>
       </div>
 
       <!-- Card 4: Reactive Engine -->
-      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-purple-500/50 transition-all flex flex-col justify-between group shadow-sm">
+      <div class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 transition-all flex flex-col justify-between group shadow-sm">
         <div>
-          <div class="w-12 h-12 bg-purple-100 dark:bg-purple-950 text-purple-600 dark:text-purple-400 rounded-lg flex items-center justify-center mb-6">
+          <div class="w-12 h-12 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded-lg flex items-center justify-center mb-6">
             <svg class="w-6 h-6 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
             </svg>
@@ -84,7 +84,7 @@
             Built-in EventTarget-based global store and dynamic router bringing route parameters, query parsing, and SPA navigation guards out of the box.
           </p>
         </div>
-        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-purple-600 dark:text-purple-400">
+        <div class="mt-6 pt-4 border-t border-slate-200 dark:border-slate-800/80 flex items-center text-xs font-semibold text-slate-700 dark:text-slate-300">
           Native Declarative Engine
         </div>
       </div>
@@ -99,8 +99,8 @@
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
 
-        <div class="bg-slate-50 dark:bg-slate-900/60 p-5 rounded-lg border border-sky-300 dark:border-sky-800">
-          <h4 class="text-base font-bold text-sky-700 dark:text-sky-400 mb-3">Boba Framework</h4>
+        <div class="bg-slate-50 dark:bg-slate-900/60 p-5 rounded-lg border border-slate-300 dark:border-slate-700">
+          <h4 class="text-base font-bold text-slate-900 dark:text-slate-100 mb-3">Boba Framework</h4>
           <ul class="text-xs space-y-2.5 text-slate-700 dark:text-slate-300">
             <li class="flex items-center gap-2"><span class="text-emerald-500 font-bold">✔</span> Fast Light DOM</li>
             <li class="flex items-center gap-2"><span class="text-emerald-500 font-bold">✔</span> No Build Pipeline</li>
@@ -135,7 +135,7 @@
     <!-- Developer Best Practices Guidance -->
     <section class="bg-[var(--boba-surface)] p-6 sm:p-8 rounded-xl border border-slate-200 dark:border-slate-800 mb-16">
       <h3 class="text-xl font-bold text-slate-900 dark:text-slate-100 mb-6 flex items-center gap-2">
-        <svg class="w-5 h-5 text-sky-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <svg class="w-5 h-5 text-slate-700 dark:text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
         </svg>
         Styling Best Practices

--- a/template/src/components/todo-page/todo-page.css
+++ b/template/src/components/todo-page/todo-page.css
@@ -1,9 +1,3 @@
-.todo-container { padding: 2rem; max-width: 600px; margin: 0 auto; }
-.add-task { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; }
-input { flex-grow: 1; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; }
-button { padding: 0.5rem 1rem; cursor: pointer; background: #007bff; color: white; border: none; border-radius: 4px; }
-ul { list-style: none; padding: 0; }
-li { display: flex; align-items: center; justify-content: space-between; padding: 0.5rem; border-bottom: 1px solid #eee; }
-.completed .task-text { text-decoration: line-through; color: #888; }
-.task-text { cursor: pointer; flex-grow: 1; }
-.delete-btn { background: #ff4d4d; color: white; border: none; padding: 0.2rem 0.5rem; border-radius: 4px; cursor: pointer; }
+:host {
+  display: block;
+}

--- a/template/src/components/todo-page/todo-page.html
+++ b/template/src/components/todo-page/todo-page.html
@@ -3,7 +3,7 @@
 
     <!-- Heading -->
     <div class="text-center mb-10">
-      <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-sky-50 dark:bg-sky-950/60 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800/60 mb-3 uppercase tracking-wider">
+      <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 mb-3 uppercase tracking-wider shadow-sm">
         Enterprise Application Demo
       </span>
       <h1 class="text-3xl sm:text-4xl font-extrabold text-slate-900 dark:text-slate-50 tracking-tight mb-2">
@@ -23,12 +23,12 @@
           type="text"
           id="new-task-input"
           placeholder="Add a new task..."
-          class="flex-grow px-4 py-3 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-slate-100 bg-white dark:bg-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 transition-all text-sm font-medium"
+          class="flex-grow px-4 py-3 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-slate-100 bg-white dark:bg-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-all text-sm font-medium"
           autocomplete="off"
         />
         <button
           id="add-task-btn"
-          class="px-5 py-3 bg-sky-600 hover:bg-sky-700 dark:bg-sky-500 dark:hover:bg-sky-400 text-white font-semibold rounded-lg transition-all shadow-sm flex items-center justify-center gap-1.5 text-sm cursor-pointer"
+          class="px-5 py-3 bg-slate-900 hover:bg-slate-800 dark:bg-slate-100 dark:hover:bg-slate-200 text-white dark:text-slate-900 font-semibold rounded-lg transition-all shadow-sm flex items-center justify-center gap-1.5 text-sm cursor-pointer"
         >
           <svg class="w-4 h-4 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -74,7 +74,7 @@
       <!-- Empty State -->
       <div id="empty-state" class="hidden py-10 text-center">
         <svg class="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-3 stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.375M9 18h3.375m1.875-10.125A2.25 2.25 0 0115.75 6H18a2.25 2.25 0 0118 20.25H6A2.25 2.25 0 0118 20.25H6A2.25 2.25 0 013.75 18V6A2.25 2.25 0 016 3.75h1.5m9 0h-9" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.375M9 18h3.375m1.875-10.125A2.25 2.25 0 0115.75 6H18a2.25 2.25 0 0118 20.25H6A2.25 2.25 0 013.75 18V6A2.25 2.25 0 016 3.75h1.5m9 0h-9" />
         </svg>
         <p class="text-sm text-slate-400 dark:text-slate-500 font-medium">No tasks found in this view.</p>
       </div>


### PR DESCRIPTION
Aligned the About and To-Do page component styles with the Home page by updating badges, buttons, focus rings, and card accents to the slate design system palette in both `src/` and `template/` directories, and removing obsolete custom CSS rules.

Fixes #103

---
*PR created automatically by Jules for task [15629841545543423222](https://jules.google.com/task/15629841545543423222) started by @sholtomaud*